### PR TITLE
Feature/#29 retrospect

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -1,9 +1,11 @@
 package com.dnd.reevserver.domain.retrospect.controller;
 
+import com.dnd.reevserver.domain.retrospect.dto.request.AddRetrospectRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.service.RetrospectService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,4 +13,23 @@ import org.springframework.web.bind.annotation.RestController;
 public class RetrospectController {
 
     private final RetrospectService retrospectService;
+
+//    //:todo 회고 전체조회
+//    @GetMapping
+//    public ResponseEntity<?> retrospect() {
+//        return ResponseEntity.ok().build();
+//    }
+//
+//    //:todo 회고 단일 조회
+//    @GetMapping
+//    public ResponseEntity<?> getRetrospect() {
+//        return ResponseEntity.ok().build();
+//    }
+
+    @PostMapping("/add")
+    public ResponseEntity<AddRetrospectResponseDto> addRetrospect(@RequestBody AddRetrospectRequestDto addRetrospectRequestDto) {
+       AddRetrospectResponseDto responseDto = retrospectService.addRetrospect(addRetrospectRequestDto);
+       return ResponseEntity.ok().body(responseDto);
+    }
+
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -1,6 +1,7 @@
 package com.dnd.reevserver.domain.retrospect.controller;
 
 import com.dnd.reevserver.domain.retrospect.dto.request.AddRetrospectRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.request.GetAllGroupRetrospectRequestDto;
 import com.dnd.reevserver.domain.retrospect.dto.request.GetRetrospectRequestDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
@@ -20,8 +21,9 @@ public class RetrospectController {
 
     //todo:페이징, 유저가 모임에 가입되어있는지 확인하는 로직 추가
     @GetMapping("/all")
-    public ResponseEntity<List<RetrospectResponseDto>> retrospect() {
-        return ResponseEntity.ok().build();
+    public ResponseEntity<List<RetrospectResponseDto>> retrospect(@RequestBody GetAllGroupRetrospectRequestDto requestDto) {
+        List<RetrospectResponseDto> retroList = retrospectService.getAllRetrospectByGruopId(requestDto);
+        return ResponseEntity.ok().body(retroList);
     }
 
     @GetMapping

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -1,11 +1,15 @@
 package com.dnd.reevserver.domain.retrospect.controller;
 
 import com.dnd.reevserver.domain.retrospect.dto.request.AddRetrospectRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.request.GetRetrospectRequestDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.service.RetrospectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -14,21 +18,21 @@ public class RetrospectController {
 
     private final RetrospectService retrospectService;
 
-//    //:todo 회고 전체조회
-//    @GetMapping
-//    public ResponseEntity<?> retrospect() {
-//        return ResponseEntity.ok().build();
-//    }
-//
-//    //:todo 회고 단일 조회
-//    @GetMapping
-//    public ResponseEntity<?> getRetrospect() {
-//        return ResponseEntity.ok().build();
-//    }
+    //todo:페이징, 유저가 모임에 가입되어있는지 확인하는 로직 추가
+    @GetMapping("/all")
+    public ResponseEntity<List<RetrospectResponseDto>> retrospect() {
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<RetrospectResponseDto> getRetrospect(@RequestBody GetRetrospectRequestDto requestDto) {
+        RetrospectResponseDto responseDto = retrospectService.getRetrospectById(requestDto);
+        return ResponseEntity.ok().body(responseDto);
+    }
 
     @PostMapping("/add")
-    public ResponseEntity<AddRetrospectResponseDto> addRetrospect(@RequestBody AddRetrospectRequestDto addRetrospectRequestDto) {
-       AddRetrospectResponseDto responseDto = retrospectService.addRetrospect(addRetrospectRequestDto);
+    public ResponseEntity<AddRetrospectResponseDto> addRetrospect(@RequestBody AddRetrospectRequestDto requestDto) {
+       AddRetrospectResponseDto responseDto = retrospectService.addRetrospect(requestDto);
        return ResponseEntity.ok().body(responseDto);
     }
 

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/AddRetrospectRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/AddRetrospectRequestDto.java
@@ -1,0 +1,8 @@
+package com.dnd.reevserver.domain.retrospect.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record AddRetrospectRequestDto(String userId, Long groupId,
+                                      String title, String content) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/GetAllGroupRetrospectRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/GetAllGroupRetrospectRequestDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.retrospect.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record GetAllGroupRetrospectRequestDto(String userId, Long groupId) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/GetAllGroupRetrospectRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/GetAllGroupRetrospectRequestDto.java
@@ -3,5 +3,5 @@ package com.dnd.reevserver.domain.retrospect.dto.request;
 import lombok.Builder;
 
 @Builder
-public record GetAllGroupRetrospectRequestDto(String userId, Long groupId) {
+public record GetAllGroupRetrospectRequestDto(Long groupId) {
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/GetRetrospectRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/GetRetrospectRequestDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.retrospect.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record GetRetrospectRequestDto(Long retrospectId) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/AddRetrospectResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/AddRetrospectResponseDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.retrospect.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AddRetrospectResponseDto(Long retrospectId) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectResponseDto.java
@@ -1,0 +1,8 @@
+package com.dnd.reevserver.domain.retrospect.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RetrospectResponseDto(Long retrosepctId, String title, String content,
+                                    String userName, String timeString, int likeCount) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/exception/RetrospectNotFoundException.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/exception/RetrospectNotFoundException.java
@@ -1,0 +1,14 @@
+package com.dnd.reevserver.domain.retrospect.exception;
+
+import com.dnd.reevserver.global.exception.GeneralException;
+
+public class RetrospectNotFoundException extends GeneralException {
+    private static final String MESSAGE = "회고ID에 해당하는 회고가 존재하지 않습니다.";
+
+    public RetrospectNotFoundException() { super(MESSAGE); }
+
+    @Override
+    public int getStatusCode() {
+        return 404;
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -1,8 +1,14 @@
 package com.dnd.reevserver.domain.retrospect.repository;
 
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
+    @Query("select r from Retrospect r where r.team.teamId = :teamId ")
+    List<Retrospect> findAllByTeamId(@Param("teamId") Long teamId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -3,5 +3,6 @@ package com.dnd.reevserver.domain.retrospect.repository;
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -3,14 +3,19 @@ package com.dnd.reevserver.domain.retrospect.service;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.member.service.MemberService;
 import com.dnd.reevserver.domain.retrospect.dto.request.AddRetrospectRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.request.GetRetrospectRequestDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import com.dnd.reevserver.domain.retrospect.exception.RetrospectNotFoundException;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
 import com.dnd.reevserver.domain.team.entity.Team;
-import com.dnd.reevserver.domain.team.repository.TeamRepository;
 import com.dnd.reevserver.domain.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +25,21 @@ public class RetrospectService {
     private final MemberService memberService;
     private final TeamService teamService;
 
+    //단일회고 조회
+    public RetrospectResponseDto getRetrospectById(GetRetrospectRequestDto getRetrospectRequestDto) {
+        Retrospect retrospect = findById(getRetrospectRequestDto.retrospectId());
+        return RetrospectResponseDto.builder()
+                .retrosepctId(retrospect.getRetrospectId())
+                .title(retrospect.getTitle())
+                .content(retrospect.getContent())
+                .userName(retrospect.getMember().getNickname())
+                .timeString(getTimeString(retrospect.getUpdatedAt()))
+                .likeCount(retrospect.getLikeCount())
+                .build();
+    }
+
+
+    //회고 작성
     public AddRetrospectResponseDto addRetrospect(AddRetrospectRequestDto addRetrospectRequestDto) {
         Member member = memberService.findById(addRetrospectRequestDto.userId());
         Team team = teamService.findById(addRetrospectRequestDto.groupId());
@@ -32,5 +52,24 @@ public class RetrospectService {
         retrospectRepository.save(retrospect);
 
         return new AddRetrospectResponseDto(retrospect.getRetrospectId());
+    }
+
+    //회고 작성시간 문자열
+    private String getTimeString(LocalDateTime time){
+        LocalDateTime now = LocalDateTime.now();
+        long timeGap = ChronoUnit.MINUTES.between(time, now);
+
+        if(timeGap < 60){
+            return timeGap + "분 전";
+        }
+        if(timeGap < 1440){
+            return ChronoUnit.HOURS.between(time, now) + "시간 전";
+        }
+        return ChronoUnit.DAYS.between(time, now) + "일 전";
+
+    }
+
+    public Retrospect findById(Long retrospectId) {
+        return retrospectRepository.findById(retrospectId).orElseThrow(RetrospectNotFoundException::new);
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -3,6 +3,7 @@ package com.dnd.reevserver.domain.retrospect.service;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.member.service.MemberService;
 import com.dnd.reevserver.domain.retrospect.dto.request.AddRetrospectRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.request.GetAllGroupRetrospectRequestDto;
 import com.dnd.reevserver.domain.retrospect.dto.request.GetRetrospectRequestDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
@@ -16,6 +17,9 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +40,22 @@ public class RetrospectService {
                 .timeString(getTimeString(retrospect.getUpdatedAt()))
                 .likeCount(retrospect.getLikeCount())
                 .build();
+    }
+
+    //그룹 회고 조회
+    public List<RetrospectResponseDto> getAllRetrospectByGruopId(GetAllGroupRetrospectRequestDto getAllGroupRetrospectRequestDto) {
+        List<Retrospect> list = retrospectRepository.findAllByTeamId(getAllGroupRetrospectRequestDto.groupId());
+        List<RetrospectResponseDto> retrospectResponseDtoList = list.stream()
+                .map(retro -> RetrospectResponseDto.builder()
+                        .retrosepctId(retro.getRetrospectId())
+                        .title(retro.getTitle())
+                        .content(retro.getContent())
+                        .userName(retro.getMember().getNickname())
+                        .timeString(getTimeString(retro.getUpdatedAt()))
+                        .likeCount(retro.getLikeCount())
+                        .build())
+                .toList();
+        return retrospectResponseDtoList;
     }
 
 

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -1,6 +1,14 @@
 package com.dnd.reevserver.domain.retrospect.service;
 
+import com.dnd.reevserver.domain.member.entity.Member;
+import com.dnd.reevserver.domain.member.service.MemberService;
+import com.dnd.reevserver.domain.retrospect.dto.request.AddRetrospectRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
+import com.dnd.reevserver.domain.team.entity.Team;
+import com.dnd.reevserver.domain.team.repository.TeamRepository;
+import com.dnd.reevserver.domain.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,4 +17,20 @@ import org.springframework.stereotype.Service;
 public class RetrospectService {
 
     private final RetrospectRepository retrospectRepository;
+    private final MemberService memberService;
+    private final TeamService teamService;
+
+    public AddRetrospectResponseDto addRetrospect(AddRetrospectRequestDto addRetrospectRequestDto) {
+        Member member = memberService.findById(addRetrospectRequestDto.userId());
+        Team team = teamService.findById(addRetrospectRequestDto.groupId());
+        Retrospect retrospect = Retrospect.builder()
+                .member(member)
+                .team(team)
+                .title(addRetrospectRequestDto.title())
+                .content(addRetrospectRequestDto.content())
+                .build();
+        retrospectRepository.save(retrospect);
+
+        return new AddRetrospectResponseDto(retrospect.getRetrospectId());
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -118,4 +118,8 @@ public class TeamService {
         return new AddTeamResponseDto(team.getTeamId());
     }
 
+    public Team findById(Long groupId) {
+        return teamRepository.findById(groupId).orElseThrow(TeamNotFoundException::new);
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> resolve #29 

## 📝 작업 내용

> 모임 회고 작성, 단일 회고 조회, 모임에 속해있는 회고목록 조회를 구현하였습니다. 

## 💬 리뷰 요구사항 (선택 사항)

> 페이지네이션은 추후 필터링과 함께 추가할 예정입니다.
추가로 조회나 작성시 유저가 그룹에 속해있는지 확인하는 로직은 이제 구현할예정입니다. 이번주 과제인 영상제출에 필요한 기능 우선 구현하였습니다. dto로 응답 추가로 필요할것 같은것들 말씀해주시면 감사하겠습니다.