### PR TITLE
Feature/#48 comment

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
@@ -1,0 +1,14 @@
+package com.dnd.reevserver.domain.comment.controller;
+
+import com.dnd.reevserver.domain.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/commet")
+@RequiredArgsConstructor
+public class CommentController {
+
+    private final CommentService commentService;
+}

--- a/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
@@ -1,14 +1,23 @@
 package com.dnd.reevserver.domain.comment.controller;
 
+import com.dnd.reevserver.domain.comment.dto.response.CommentResponseDto;
 import com.dnd.reevserver.domain.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
-@RequestMapping("/api/v1/commet")
+@RequestMapping("/api/v1/comment")
 @RequiredArgsConstructor
 public class CommentController {
 
     private final CommentService commentService;
+
+    @GetMapping("/{retrospectId}/all")
+    public ResponseEntity<List<CommentResponseDto>> getAllComment(@PathVariable Long retrospectId) {
+        List<CommentResponseDto> responseDtoList = commentService.getAllComment(retrospectId);
+        return ResponseEntity.ok().body(responseDtoList);
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.dnd.reevserver.domain.comment.controller;
 
+import com.dnd.reevserver.domain.comment.dto.request.AddCommentRequestDto;
 import com.dnd.reevserver.domain.comment.dto.response.CommentResponseDto;
 import com.dnd.reevserver.domain.comment.service.CommentService;
 import lombok.RequiredArgsConstructor;
@@ -20,4 +21,11 @@ public class CommentController {
         List<CommentResponseDto> responseDtoList = commentService.getAllComment(retrospectId);
         return ResponseEntity.ok().body(responseDtoList);
     }
+
+    @PostMapping
+    public ResponseEntity<CommentResponseDto> addComment(@RequestBody AddCommentRequestDto requestDto) {
+        CommentResponseDto commentResponseDto = commentService.addComment(requestDto);
+        return ResponseEntity.ok().body(commentResponseDto);
+    }
+
 }

--- a/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/controller/CommentController.java
@@ -16,7 +16,7 @@ public class CommentController {
 
     private final CommentService commentService;
 
-    @GetMapping("/{retrospectId}/all")
+    @GetMapping("/{retrospectId}")
     public ResponseEntity<List<CommentResponseDto>> getAllComment(@PathVariable Long retrospectId) {
         List<CommentResponseDto> responseDtoList = commentService.getAllComment(retrospectId);
         return ResponseEntity.ok().body(responseDtoList);

--- a/src/main/java/com/dnd/reevserver/domain/comment/dto/request/AddCommentRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/dto/request/AddCommentRequestDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.comment.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record AddCommentRequestDto(String userId, Long retrospectId, String content) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/dto/response/CommentResponseDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentResponseDto(Long commentId, String userId, Long retrospectId, String content, String nickName,String timeMessage) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/comment/dto/response/CommentResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/dto/response/CommentResponseDto.java
@@ -3,5 +3,6 @@ package com.dnd.reevserver.domain.comment.dto.response;
 import lombok.Builder;
 
 @Builder
-public record CommentResponseDto(Long commentId, String userId, Long retrospectId, String content, String nickName,String timeMessage) {
+public record CommentResponseDto(Long commentId, String userId, Long retrospectId,
+                                 String content, String nickName,String timeMessage) {
 }

--- a/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
@@ -1,0 +1,48 @@
+package com.dnd.reevserver.domain.comment.entity;
+
+import com.dnd.reevserver.domain.member.entity.Member;
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import com.dnd.reevserver.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long commentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "retrospect_id", nullable = false)
+    private Retrospect retrospect;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private Comment parentComment;
+
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    private String content;
+
+    @Builder
+    public Comment(Long commentId, Member member, Retrospect retrospect, String content) {
+        this.commentId = commentId;
+        this.member = member;
+        this.retrospect = retrospect;
+        this.content = content;
+    }
+
+    public void updateComment(Comment comment) {
+        this.content = comment.getContent();
+    }
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
@@ -8,6 +8,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 @Getter
@@ -32,6 +33,10 @@ public class Comment extends BaseEntity {
 
     @Column(nullable = false, length = 500)
     private String content;
+
+    @ColumnDefault("false")
+    @Column(columnDefinition = "TINYINT(1)")
+    private boolean isDeleted;
 
     @Builder
     public Comment(Long commentId, Member member, Retrospect retrospect, String content) {

--- a/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "parent_comment_id")
     private Comment parentComment;
 
-    @Column(nullable = false, columnDefinition = "LONGTEXT")
+    @Column(nullable = false, length = 500)
     private String content;
 
     @Builder

--- a/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/entity/Comment.java
@@ -39,8 +39,7 @@ public class Comment extends BaseEntity {
     private boolean isDeleted;
 
     @Builder
-    public Comment(Long commentId, Member member, Retrospect retrospect, String content) {
-        this.commentId = commentId;
+    public Comment(Member member, Retrospect retrospect, String content) {
         this.member = member;
         this.retrospect = retrospect;
         this.content = content;

--- a/src/main/java/com/dnd/reevserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.comment.repository;
+
+import com.dnd.reevserver.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/dnd/reevserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/repository/CommentRepository.java
@@ -1,7 +1,13 @@
 package com.dnd.reevserver.domain.comment.repository;
 
 import com.dnd.reevserver.domain.comment.entity.Comment;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("select c from Comment c where c.retrospect.retrospectId = :retrospectId")
+    List<Comment> findAllByRetrospectId(@Param("retrospectId") Long retrospectId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/service/CommentService.java
@@ -1,0 +1,12 @@
+package com.dnd.reevserver.domain.comment.service;
+
+import com.dnd.reevserver.domain.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+}

--- a/src/main/java/com/dnd/reevserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/service/CommentService.java
@@ -1,12 +1,55 @@
 package com.dnd.reevserver.domain.comment.service;
 
+import com.dnd.reevserver.domain.comment.dto.response.CommentResponseDto;
+import com.dnd.reevserver.domain.comment.entity.Comment;
 import com.dnd.reevserver.domain.comment.repository.CommentRepository;
+import com.dnd.reevserver.domain.member.entity.Member;
+import com.dnd.reevserver.domain.member.service.MemberService;
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import com.dnd.reevserver.domain.retrospect.service.RetrospectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final RetrospectService retrospectService;
+    private final MemberService memberService;
+
+    public List<CommentResponseDto> getAllComment(Long retrospectId) {
+        Retrospect retrospect = retrospectService.findById(retrospectId);
+        List<Comment> list = commentRepository.findAllByRetrospectId(retrospectId);
+        List<CommentResponseDto> commentResponseDtoList = list.stream()
+                .map(comment -> CommentResponseDto.builder()
+                        .commentId(comment.getCommentId())
+                        .userId(comment.getMember().getUserId())
+                        .retrospectId(comment.getRetrospect().getRetrospectId())
+                        .content(comment.getContent())
+                        .nickName(comment.getMember().getNickname())
+                        .timeMessage(getTimeString(comment.getUpdatedAt()))
+                        .build())
+                .toList();
+        return commentResponseDtoList;
+    }
+
+    private String getTimeString(LocalDateTime time){
+        LocalDateTime now = LocalDateTime.now();
+        long timeGap = ChronoUnit.MINUTES.between(time, now);
+
+        if(timeGap < 60){
+            return timeGap + "분 전";
+        }
+        if(timeGap < 1440){
+            return ChronoUnit.HOURS.between(time, now) + "시간 전";
+        }
+        return ChronoUnit.DAYS.between(time, now) + "일 전";
+
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/comment/service/CommentService.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.dnd.reevserver.domain.comment.service;
 
+import com.dnd.reevserver.domain.comment.dto.request.AddCommentRequestDto;
 import com.dnd.reevserver.domain.comment.dto.response.CommentResponseDto;
 import com.dnd.reevserver.domain.comment.entity.Comment;
 import com.dnd.reevserver.domain.comment.repository.CommentRepository;
@@ -23,6 +24,7 @@ public class CommentService {
     private final RetrospectService retrospectService;
     private final MemberService memberService;
 
+    //댓글 목록 조회
     public List<CommentResponseDto> getAllComment(Long retrospectId) {
         Retrospect retrospect = retrospectService.findById(retrospectId);
         List<Comment> list = commentRepository.findAllByRetrospectId(retrospectId);
@@ -50,6 +52,27 @@ public class CommentService {
             return ChronoUnit.HOURS.between(time, now) + "시간 전";
         }
         return ChronoUnit.DAYS.between(time, now) + "일 전";
+    }
 
+    //댓글 작성
+    public CommentResponseDto addComment(AddCommentRequestDto requestDto) {
+        Member member = memberService.findById(requestDto.userId());
+        Retrospect retrospect = retrospectService.findById(requestDto.retrospectId());
+
+        Comment comment = Comment.builder()
+                .member(member)
+                .retrospect(retrospect)
+                .content(requestDto.content())
+                .build();
+        commentRepository.save(comment);
+        CommentResponseDto responseDto = CommentResponseDto.builder()
+                .commentId(comment.getCommentId())
+                .userId(member.getUserId())
+                .retrospectId(retrospect.getRetrospectId())
+                .content(comment.getContent())
+                .nickName(member.getNickname())
+                .timeMessage(getTimeString(comment.getUpdatedAt()))
+                .build();
+        return responseDto;
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) resolve #48

## 📝 작업 내용

> mvp에들어갈 댓글 작성, 댓글 목록 조회를 우선 구현하였습니다. 

## 💬 리뷰 요구사항 (선택 사항)

> 댓글 수정은 댓글 삭제와 함께 구현하려고 하는데 대댓글을 포함한 댓글 삭제 로직에 관하여 
>1. 댓글 삭제시 대댓글들도 전부 삭제
>2. 댓글 삭제시 대댓글들은 유지
>이렇게 갔을때 어떤 방식으로 구현해야할까요?

>또 제가 이때까지 아무런 생각없이 url을 짰던거같아 @PathVariable등과 같은것을 활용하여 바꾸는것을 생각중인데, 아마 일단 다음주가 데모데이이니 일단 유지를 하는게 나을까요? 아니면 프론트와 빨리 이야기해서 지금 다 바꾸는게 나을까요?
