### PR TITLE
feat:인기모임 조회시 최근글도 하나 조회

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -1,7 +1,9 @@
 package com.dnd.reevserver.domain.retrospect.repository;
 
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import com.dnd.reevserver.domain.team.entity.Team;
 import io.lettuce.core.dynamic.annotation.Param;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +16,6 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 
     @Query("select count(r) from Retrospect r WHERE r.team.groupId = :groupId")
     long countByGroupId(Long groupId);
+
+    Optional<Retrospect> findFirstByTeam_GroupIdOrderByUpdatedAtDesc(Long groupId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
@@ -60,8 +60,8 @@ public class TeamController implements TeamControllerDocs{
     }
 
     @GetMapping("/popular")
-    public ResponseEntity<List<TeamResponseDto>> getPopularGroups(){
-        List<TeamResponseDto> popularGroup = groupService.getPopularGroups();
+    public ResponseEntity<List<GetPopularGroupResponseDto>> getPopularGroups(){
+        List<GetPopularGroupResponseDto> popularGroup = groupService.getPopularGroups();
         return ResponseEntity.ok().body(popularGroup);
     }
 

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
@@ -7,6 +7,7 @@ import com.dnd.reevserver.domain.team.dto.request.JoinGroupRequestDto;
 import com.dnd.reevserver.domain.team.dto.request.LeaveGroupRequestDto;
 import com.dnd.reevserver.domain.team.dto.response.AddFavoriteGroupResponseDto;
 import com.dnd.reevserver.domain.team.dto.response.AddTeamResponseDto;
+import com.dnd.reevserver.domain.team.dto.response.GetPopularGroupResponseDto;
 import com.dnd.reevserver.domain.team.dto.response.JoinGroupResponseDto;
 import com.dnd.reevserver.domain.team.dto.response.LeaveGroupResponseDto;
 import com.dnd.reevserver.domain.team.dto.response.TeamResponseDto;
@@ -44,7 +45,7 @@ public interface TeamControllerDocs {
     public ResponseEntity<LeaveGroupResponseDto> LeaveGroup(@AuthenticationPrincipal String userId, @RequestBody LeaveGroupRequestDto requestDto);
 
     @Operation(summary = "인기 모임 조회 API", description = "인기 모임을 조회합니다.")
-    public ResponseEntity<List<TeamResponseDto>> getPopularGroups();
+    public ResponseEntity<List<GetPopularGroupResponseDto>> getPopularGroups();
 
     @Operation(summary = "추천 모임 조회 API", description = "추천 모임을 조회합니다.")
     public ResponseEntity<List<TeamResponseDto>> getRecommendGroups(@AuthenticationPrincipal String userId);

--- a/src/main/java/com/dnd/reevserver/domain/team/dto/response/GetPopularGroupResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/dto/response/GetPopularGroupResponseDto.java
@@ -1,0 +1,8 @@
+package com.dnd.reevserver.domain.team.dto.response;
+
+
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
+
+public record GetPopularGroupResponseDto(TeamResponseDto groupResponseDto, RetrospectResponseDto retrospectResponseDto) {
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -8,6 +8,8 @@ import com.dnd.reevserver.domain.member.dto.request.GetAllUserGroupRequestDto;
 import com.dnd.reevserver.domain.member.entity.FeatureKeyword;
 import com.dnd.reevserver.domain.member.repository.FeatureKeywordRepository;
 import com.dnd.reevserver.domain.member.service.FeatureKeywordService;
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
 import com.dnd.reevserver.domain.retrospect.service.RetrospectService;
 import com.dnd.reevserver.domain.team.dto.request.*;
@@ -226,24 +228,41 @@ public class TeamService {
 
     //인기모임 조회
     @Transactional(readOnly = true)
-    public List<TeamResponseDto> getPopularGroups(){
+    public List<GetPopularGroupResponseDto> getPopularGroups(){
         List<Team> groups = teamRepository.findAllPopluarGroups();
-        List<TeamResponseDto> groupList = groups.stream()
-            .map(team -> TeamResponseDto.builder()
-                .groupId(team.getGroupId())
-                .groupName(team.getGroupName())
-                .description(team.getDescription())
-                .introduction(team.getIntroduction())
-                .userCount(team.getUserTeams().size())
-                .recentActString(timeStringUtil.getTimeString(team.getRecentAct()))
-                .categoryNames(
-                    team.getTeamCategories().stream()
-                        .map(teamCategory -> teamCategory.getCategory().getCategoryName())
-                        .toList()
-                )
-                .retrospectCount(retrospectRepository.countByGroupId(team.getGroupId()))
-                .build())
+        List<GetPopularGroupResponseDto> groupList = groups.stream()
+            .map(team -> {
+                TeamResponseDto teamResponseDto = TeamResponseDto.builder()
+                        .groupId(team.getGroupId())
+                        .groupName(team.getGroupName())
+                        .description(team.getDescription())
+                        .introduction(team.getIntroduction())
+                        .userCount(team.getUserTeams().size())
+                        .recentActString(timeStringUtil.getTimeString(team.getRecentAct()))
+                        .categoryNames(
+                            team.getTeamCategories().stream()
+                                .map(teamCategory -> teamCategory.getCategory().getCategoryName())
+                                .toList()
+                        )
+                        .retrospectCount(retrospectRepository.countByGroupId(team.getGroupId()))
+                        .build();
+                Optional<Retrospect> retrospect = retrospectRepository.findFirstByTeam_GroupIdOrderByUpdatedAtDesc(team.getGroupId());
+                RetrospectResponseDto retrospectResponseDto = null;
+                if(retrospect.isPresent()){
+                    Retrospect retro = retrospect.get();
+                   retrospectResponseDto = RetrospectResponseDto.builder()
+                        .retrospectId(retro.getRetrospectId())
+                        .title(retro.getTitle())
+                        .content(retro.getContent())
+                        .userName(retro.getMember().getNickname())
+                        .timeString(timeStringUtil.getTimeString(retro.getUpdatedAt()))
+                        .likeCount(retro.getLikeCount())
+                        .build();
+                }
+               return new GetPopularGroupResponseDto(teamResponseDto, retrospectResponseDto);
+            })
             .toList();
+
         return groupList;
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) resolve #72

## 📝 작업 내용

> 프론트의 요청에 따라 인기모임 조회시 최근글도 하나 조회되게 변경하였습니다.

## 💬 리뷰 요구사항 (선택 사항)

> mvp를 위해 일단 돌아가게 해야하므로, 일단 진짜 작동만 하게 해놨습니다. 나중에 최적화랑 리팩토링할때 고치겠습니다.