### PR TITLE
Feat/#88 stat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
     implementation group: 'org.springframework.cloud', name: 'spring-cloud-aws-autoconfigure', version: '2.2.6.RELEASE'
     implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
+
+    // lambda
+    implementation 'software.amazon.awssdk:lambda:2.20.130'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dnd/reevserver/domain/category/entity/MemoCategory.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/entity/MemoCategory.java
@@ -1,0 +1,39 @@
+package com.dnd.reevserver.domain.category.entity;
+
+import com.dnd.reevserver.domain.memo.entity.Memo;
+import com.dnd.reevserver.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memoCategoryId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "memo_id", nullable = false)
+    private Memo memo;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
+
+    public void updateMemo(Memo memo) {
+        this.memo = memo;
+    }
+
+    public void updateCategory(Category category) {
+        this.category = category;
+    }
+
+    public MemoCategory(Memo memo, Category category) {
+        this.memo = memo;
+        this.category = category;
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
@@ -1,0 +1,11 @@
+package com.dnd.reevserver.domain.category.repository;
+
+import com.dnd.reevserver.domain.category.entity.MemoCategory;
+import com.dnd.reevserver.domain.memo.entity.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemoCategoryRepository extends JpaRepository<MemoCategory, Long> {
+    List<MemoCategory> findByMemo(Memo memo);
+}

--- a/src/main/java/com/dnd/reevserver/domain/member/controller/AuthController.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/controller/AuthController.java
@@ -49,11 +49,11 @@ public class AuthController {
 
         ResponseCookie refreshCookie = CookieUtils.createReissueCookie(
                 "refresh_token",
-                reissuedToken.getRefreshToken(),
+                reissuedToken.refreshToken(),
                 60 * 60 * 24 * 7);
 
         return ResponseEntity.ok()
-                .header(HttpHeaders.AUTHORIZATION, reissuedToken.getAccessToken())
+                .header(HttpHeaders.AUTHORIZATION, reissuedToken.accessToken())
                 .header(HttpHeaders.SET_COOKIE, refreshCookie.toString())
                 .build();
     }

--- a/src/main/java/com/dnd/reevserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/controller/MemberController.java
@@ -66,4 +66,6 @@ public class MemberController {
         List<TeamResponseDto> responseList = memberService.getAllGroups(userId);
         return ResponseEntity.ok().body(responseList);
     }
+
+    // 유저의 임시글 수
 }

--- a/src/main/java/com/dnd/reevserver/domain/member/dto/response/MemberResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/dto/response/MemberResponseDto.java
@@ -1,22 +1,9 @@
 package com.dnd.reevserver.domain.member.dto.response;
 
-import com.dnd.reevserver.domain.member.entity.FeatureKeyword;
-import com.dnd.reevserver.domain.member.entity.Member;
-import lombok.Getter;
+import lombok.Builder;
 
 import java.util.List;
 
-@Getter
-public class MemberResponseDto {
-    private final String userId;
-    private final String nickname;
-    private final String profileUrl;
-    private final List<String> featureKeywordList;
-
-    public MemberResponseDto(Member member, List<FeatureKeyword> featureKeywordList){
-        this.userId = member.getUserId();
-        this.nickname = member.getNickname();
-        this.profileUrl = member.getProfileUrl();
-        this.featureKeywordList = featureKeywordList.stream().map(FeatureKeyword::getKeywordName).toList();
-    }
+@Builder
+public record MemberResponseDto (String userId, String nickname, String profileUrl, List<String> featureKeywordList){
 }

--- a/src/main/java/com/dnd/reevserver/domain/member/dto/response/ReissueResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/dto/response/ReissueResponseDto.java
@@ -1,15 +1,5 @@
 package com.dnd.reevserver.domain.member.dto.response;
 
-import lombok.Getter;
+public record ReissueResponseDto(String accessToken, String refreshToken) {
 
-@Getter
-public class ReissueResponseDto {
-
-    private final String accessToken;
-    private final String refreshToken;
-
-    public ReissueResponseDto(String accessToken, String refreshToken) {
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/service/MemberService.java
@@ -36,7 +36,14 @@ public class MemberService {
 
     // 회원 내용 읽기 (컨트롤러에서)
     public MemberResponseDto findByUserId(String userId){
-        return new MemberResponseDto(findById(userId), featureKeywordRepository.findAllByUserId(userId));
+        Member member = findById(userId);
+        List<String> featureKeywords = featureKeywordRepository.findAllByUserId(userId).stream().map(FeatureKeyword::getKeywordName).toList();
+        return MemberResponseDto.builder()
+                .userId(member.getUserId())
+                .nickname(member.getNickname())
+                .profileUrl(member.getProfileUrl())
+                .featureKeywordList(featureKeywords)
+                .build();
     }
 
     // 회원 정보 수정 (nickname, profileUrl)

--- a/src/main/java/com/dnd/reevserver/domain/memo/controller/MemoController.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/controller/MemoController.java
@@ -29,6 +29,12 @@ public class MemoController {
         return ResponseEntity.ok(memos);
     }
 
+    @Operation(summary = "유저의 메모 수 조회")
+    @GetMapping("/count")
+    public ResponseEntity<Integer> countMemosByUserId(@AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(memoService.countMemosByUserId(userId));
+    }
+
     @Operation(summary = "메모 생성")
     @PostMapping
     public ResponseEntity<String> createMemo(@AuthenticationPrincipal String userId, @RequestBody CreateMemoRequestDto dto) {

--- a/src/main/java/com/dnd/reevserver/domain/memo/dto/request/CreateMemoRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/dto/request/CreateMemoRequestDto.java
@@ -1,4 +1,6 @@
 package com.dnd.reevserver.domain.memo.dto.request;
 
-public record CreateMemoRequestDto(String content) {
+import java.util.List;
+
+public record CreateMemoRequestDto(String title, String content, String templateName, List<String> categoriesName) {
 }

--- a/src/main/java/com/dnd/reevserver/domain/memo/dto/response/MemoResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/dto/response/MemoResponseDto.java
@@ -7,11 +7,15 @@ import lombok.Getter;
 public class MemoResponseDto {
     private final Long memoId;
     private final String userId;
+    private final String title;
     private final String content;
+    private final String templateName;
 
     public MemoResponseDto(Memo memo) {
         this.memoId = memo.getMemoId();
         this.userId = memo.getMember().getUserId();
+        this.title = memo.getTitle();
         this.content = memo.getContent();
+        this.templateName = memo.getTemplate().getTemplateName();
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/memo/dto/response/MemoResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/dto/response/MemoResponseDto.java
@@ -1,21 +1,7 @@
 package com.dnd.reevserver.domain.memo.dto.response;
 
-import com.dnd.reevserver.domain.memo.entity.Memo;
-import lombok.Getter;
+import lombok.Builder;
 
-@Getter
-public class MemoResponseDto {
-    private final Long memoId;
-    private final String userId;
-    private final String title;
-    private final String content;
-    private final String templateName;
-
-    public MemoResponseDto(Memo memo) {
-        this.memoId = memo.getMemoId();
-        this.userId = memo.getMember().getUserId();
-        this.title = memo.getTitle();
-        this.content = memo.getContent();
-        this.templateName = memo.getTemplate().getTemplateName();
-    }
+@Builder
+public record MemoResponseDto(Long memoId, String userId, String title, String content, String templateName){
 }

--- a/src/main/java/com/dnd/reevserver/domain/memo/entity/Memo.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/entity/Memo.java
@@ -1,6 +1,7 @@
 package com.dnd.reevserver.domain.memo.entity;
 
 import com.dnd.reevserver.domain.member.entity.Member;
+import com.dnd.reevserver.domain.template.entity.Template;
 import com.dnd.reevserver.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -21,6 +22,13 @@ public class Memo extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Member member;
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "content", nullable = false, columnDefinition = "LONGTEXT")
     private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "template_id")
+    private Template template;
 }

--- a/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
@@ -42,6 +42,11 @@ public class MemoService {
                 .map(MemoResponseDto::new).collect(Collectors.toList());
     }
 
+    // 유저의 메모 수 조회
+    public Integer countMemosByUserId(String userId){
+        return memoRepository.findMemosByMember(memberService.findById(userId)).size();
+    }
+
     // 메모 생성
     @Transactional
     public void createMemo(String userId, CreateMemoRequestDto dto){

--- a/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
@@ -33,13 +33,27 @@ public class MemoService {
     }
 
     public MemoResponseDto findMemoById(Long id) {
-        return new MemoResponseDto(findById(id));
+        Memo memo = findById(id);
+        return MemoResponseDto.builder()
+                .memoId(memo.getMemoId())
+                .title(memo.getTitle())
+                .userId(memo.getMember().getUserId())
+                .content(memo.getContent())
+                .templateName(memo.getTemplate().getTemplateName())
+                .build();
     }
 
     // 유저의 전체 메모 조회
     public List<MemoResponseDto> findMemosByUserId(String userId){
         return memoRepository.findMemosByMember(memberService.findById(userId)).stream()
-                .map(MemoResponseDto::new).collect(Collectors.toList());
+                .map(m -> MemoResponseDto.builder()
+                        .memoId(m.getMemoId())
+                        .title(m.getTitle())
+                        .userId(m.getMember().getUserId())
+                        .content(m.getContent())
+                        .templateName(m.getTemplate().getTemplateName())
+                        .build()
+                ).collect(Collectors.toList());
     }
 
     // 유저의 메모 수 조회

--- a/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
@@ -1,14 +1,21 @@
 package com.dnd.reevserver.domain.memo.service;
 
+import com.dnd.reevserver.domain.category.entity.MemoCategory;
+import com.dnd.reevserver.domain.category.repository.MemoCategoryRepository;
+import com.dnd.reevserver.domain.category.service.CategoryService;
 import com.dnd.reevserver.domain.member.service.MemberService;
 import com.dnd.reevserver.domain.memo.dto.request.CreateMemoRequestDto;
 import com.dnd.reevserver.domain.memo.dto.response.MemoResponseDto;
 import com.dnd.reevserver.domain.memo.entity.Memo;
 import com.dnd.reevserver.domain.memo.exception.MemoNotFoundException;
 import com.dnd.reevserver.domain.memo.repository.MemoRepository;
+import com.dnd.reevserver.domain.template.entity.Template;
+import com.dnd.reevserver.domain.template.service.TemplateService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -17,6 +24,9 @@ import java.util.stream.Collectors;
 public class MemoService {
     private final MemoRepository memoRepository;
     private final MemberService memberService;
+    private final TemplateService templateService;
+    private final CategoryService categoryService;
+    private final MemoCategoryRepository memoCategoryRepository;
 
     public Memo findById(Long id) {
         return memoRepository.findById(id).orElseThrow(MemoNotFoundException::new);
@@ -33,15 +43,31 @@ public class MemoService {
     }
 
     // 메모 생성
+    @Transactional
     public void createMemo(String userId, CreateMemoRequestDto dto){
-        memoRepository.save(Memo.builder()
+        Template template = templateService.findByName(dto.templateName());
+        Memo memo = Memo.builder()
                 .member(memberService.findById(userId))
+                .title(dto.title())
                 .content(dto.content())
-                .build());
+                .template(template)
+                .build();
+        // 메모-태그 생성
+        memoRepository.save(memo);
+        List<MemoCategory> memoCategories = new ArrayList<>();
+        for(String categoryName : dto.categoriesName()){
+            MemoCategory mc = new MemoCategory(memo, categoryService.findByCategoryName(categoryName));
+            memoCategories.add(mc);
+        }
+        memoCategoryRepository.saveAll(memoCategories);
     }
 
     // 메모 삭제
+    @Transactional
     public void deleteMemo(Long memoId){
+        Memo memo = findById(memoId);
+        List<MemoCategory> memoCategories = memoCategoryRepository.findByMemo(memo);
+        memoCategoryRepository.deleteAll(memoCategories);
         memoRepository.deleteById(memoId);
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -10,6 +10,7 @@ import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.retrospect.exception.RetrospectAuthorException;
 import com.dnd.reevserver.domain.retrospect.exception.RetrospectNotFoundException;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
+import com.dnd.reevserver.domain.statistics.service.LambdaService;
 import com.dnd.reevserver.domain.team.entity.Team;
 import com.dnd.reevserver.domain.team.service.TeamService;
 import com.dnd.reevserver.domain.userTeam.entity.UserTeam;
@@ -30,6 +31,7 @@ public class RetrospectService {
     private final MemberService memberService;
     private final TeamService teamService;
     private final TimeStringUtil timeStringUtil;
+    private final LambdaService lambdaService;
 
     //단일회고 조회
     @Transactional(readOnly = true)
@@ -103,6 +105,9 @@ public class RetrospectService {
             .build();
         retrospectRepository.save(retrospect);
 
+        // 회고 작성을 통계에 등록
+        lambdaService.writeStatistics(userId);
+
         return new AddRetrospectResponseDto(retrospect.getRetrospectId());
 
     }
@@ -152,6 +157,4 @@ public class RetrospectService {
     public long countByGroupId(Long groupId) {
         return retrospectRepository.countByGroupId(groupId);
     }
-
-
 }

--- a/src/main/java/com/dnd/reevserver/domain/statistics/service/LambdaService.java
+++ b/src/main/java/com/dnd/reevserver/domain/statistics/service/LambdaService.java
@@ -1,0 +1,29 @@
+package com.dnd.reevserver.domain.statistics.service;
+
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvocationType;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+
+@Service
+public class LambdaService {
+    private final LambdaClient lambdaClient;
+
+    public LambdaService() {
+        this.lambdaClient = LambdaClient.builder()
+                .credentialsProvider(DefaultCredentialsProvider.create()) // IAM Credentials 자동 감지
+                .build();
+    }
+
+    public void triggerLambda(String functionName, String payload) {
+        InvokeRequest request = InvokeRequest.builder()
+                .functionName(functionName)
+                .payload(SdkBytes.fromUtf8String(payload)) // JSON 데이터 전달
+                .invocationType(InvocationType.EVENT) // 비동기 실행 설정
+                .build();
+
+        lambdaClient.invoke(request);
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/statistics/service/LambdaService.java
+++ b/src/main/java/com/dnd/reevserver/domain/statistics/service/LambdaService.java
@@ -1,23 +1,49 @@
 package com.dnd.reevserver.domain.statistics.service;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 import software.amazon.awssdk.services.lambda.model.InvocationType;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+
+import java.time.LocalDate;
 
 @Service
 public class LambdaService {
     private final LambdaClient lambdaClient;
 
-    public LambdaService() {
+    @Value("${lambda.function.write}")
+    private String writeFunctionName;
+
+    public LambdaService(@Value("${cloud.aws.region.static}") String AWS_REGION,
+                         @Value("${cloud.aws.credentials.access-key}") String ACCESS_KEY,
+                         @Value("${cloud.aws.credentials.secret-key}") String SECRET_KEY) {
         this.lambdaClient = LambdaClient.builder()
-                .credentialsProvider(DefaultCredentialsProvider.create()) // IAM Credentials 자동 감지
+                .region(Region.of(AWS_REGION))
+                .credentialsProvider(() -> new AwsCredentials() {
+                    @Override
+                    public String accessKeyId() {
+                        return ACCESS_KEY;
+                    }
+
+                    @Override
+                    public String secretAccessKey() {
+                        return SECRET_KEY;
+                    }
+                })
                 .build();
     }
 
-    public void triggerLambda(String functionName, String payload) {
+    public void writeStatistics(String userId){
+        String payload = String.format("{\"userId\": \"%s\", \"date\": \"%s\"}", userId, LocalDate.now());
+        triggerLambda(writeFunctionName, payload);
+    }
+
+    private void triggerLambda(String functionName, String payload) {
         InvokeRequest request = InvokeRequest.builder()
                 .functionName(functionName)
                 .payload(SdkBytes.fromUtf8String(payload)) // JSON 데이터 전달

--- a/src/main/java/com/dnd/reevserver/domain/template/dto/response/TemplateResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/dto/response/TemplateResponseDto.java
@@ -1,36 +1,27 @@
 package com.dnd.reevserver.domain.template.dto.response;
 
-import com.dnd.reevserver.domain.category.entity.TemplateCategory;
 import com.dnd.reevserver.domain.template.entity.Template;
-import lombok.Getter;
-
-import java.util.ArrayList;
+import lombok.Builder;
 import java.util.List;
 
-@Getter
-public class TemplateResponseDto {
-    private final Long templateId;
-    private final String templateName;
-    private final String content;
-    private final String preset;
-    private final boolean isPublic;
-    private final String userId;
-    private final List<String> categories;
+@Builder
+public record TemplateResponseDto(Long templateId, String templateName, String content, String preset,
+                                  boolean isPublic, String userId, List<String> categories){
 
-    public TemplateResponseDto(Template template) {
-        this.templateId = template.getTemplateId();
-        this.templateName = template.getTemplateName();
-        this.content = template.getContent();
-        this.isPublic = template.isPublic();
-        this.preset = template.getPreset();
-        this.userId = template.isPublic() ? "public" : template.getMember().getUserId();
-
-        // 스트림 API를 사용하여 categories 리스트 변환 & 불변 리스트로 저장
-        this.categories = List.copyOf(
-                template.getTemplateCategories().stream()
-                        .map(tc -> tc.getCategory().getCategoryName())
-                        .toList()
-        );
-    }
+//    public TemplateResponseDto(Template template) {
+//        this.templateId = template.getTemplateId();
+//        this.templateName = template.getTemplateName();
+//        this.content = template.getContent();
+//        this.isPublic = template.isPublic();
+//        this.preset = template.getPreset();
+//        this.userId = template.isPublic() ? "public" : template.getMember().getUserId();
+//
+//        // 스트림 API를 사용하여 categories 리스트 변환 & 불변 리스트로 저장
+//        this.categories = List.copyOf(
+//                template.getTemplateCategories().stream()
+//                        .map(tc -> tc.getCategory().getCategoryName())
+//                        .toList()
+//        );
+//    }
 }
 

--- a/src/main/java/com/dnd/reevserver/domain/template/entity/Template.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/entity/Template.java
@@ -20,10 +20,10 @@ public class Template extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long templateId;
 
-    @Column(name = "template_name", nullable = false, length = 200)
+    @Column(name = "template_name", nullable = false, length = 200, unique = true)
     private String templateName;
 
-    @Column(name = "content", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "content", nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
     @Column(name = "is_public", nullable = false)
@@ -33,7 +33,7 @@ public class Template extends BaseEntity {
     @JoinColumn(name = "user_id")
     private Member member; // 유저 전용 템플릿의 소유자 (공용 템플릿일 경우 null)
 
-    @Column(name = "preset", nullable = false, columnDefinition = "TEXT")
+    @Column(name = "preset", nullable = false, columnDefinition = "LONGTEXT")
     private String preset;
 
     @OneToMany(mappedBy = "template")

--- a/src/main/java/com/dnd/reevserver/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/repository/TemplateRepository.java
@@ -14,4 +14,6 @@ public interface TemplateRepository extends JpaRepository<Template, Long> {
 
     @Query("SELECT t FROM Template t WHERE t.isPublic = true")
     List<Template> findByIsPublicTrue();
+
+    Template findByTemplateName(String templateName);
 }

--- a/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
@@ -44,20 +44,64 @@ public class TemplateService {
     public List<TemplateResponseDto> findCustomTemplatesByUser(String userId) {
         Member member = memberService.findById(userId);
         return templateRepository.findByMemberAndIsPublicFalse(member).stream()
-                .map(TemplateResponseDto::new)
+                .map(t -> TemplateResponseDto.builder()
+                        .templateId(t.getTemplateId())
+                        .templateName(t.getTemplateName())
+                        .content(t.getContent())
+                        .preset(t.getPreset())
+                        .isPublic(t.isPublic())
+                        .userId(t.isPublic() ? "public" : t.getMember().getUserId())
+                        .categories(
+                                List.copyOf(
+                                    t.getTemplateCategories().stream()
+                                        .map(tc -> tc.getCategory().getCategoryName())
+                                        .toList()
+                                )
+                        )
+                        .build())
                 .collect(Collectors.toList());
     }
 
     // 공용 템플릿 조회
     public List<TemplateResponseDto> findPublicTemplates() {
         return templateRepository.findByIsPublicTrue().stream()
-                .map(TemplateResponseDto::new)
+                .map(
+                        t -> TemplateResponseDto.builder()
+                                .templateId(t.getTemplateId())
+                                .templateName(t.getTemplateName())
+                                .content(t.getContent())
+                                .preset(t.getPreset())
+                                .isPublic(t.isPublic())
+                                .userId(t.isPublic() ? "public" : t.getMember().getUserId())
+                                .categories(
+                                        List.copyOf(
+                                                t.getTemplateCategories().stream()
+                                                        .map(tc -> tc.getCategory().getCategoryName())
+                                                        .toList()
+                                        )
+                                )
+                                .build()
+                )
                 .collect(Collectors.toList());
     }
 
     // 템플릿 개별 조회
     public TemplateResponseDto findTemplateById(Long id) {
-        return new TemplateResponseDto(findById(id));
+        Template template = findById(id);
+        return TemplateResponseDto.builder()
+                .templateId(template.getTemplateId())
+                .templateName(template.getTemplateName())
+                .content(template.getContent())
+                .preset(template.getPreset())
+                .isPublic(template.isPublic())
+                .userId(template.isPublic() ? "public" : template.getMember().getUserId())
+                .categories(
+                        List.copyOf(
+                                template.getTemplateCategories().stream()
+                                        .map(tc -> tc.getCategory().getCategoryName())
+                                        .toList()
+                        )
+                ).build();
     }
 
     // 커스텀 템플릿 추가

--- a/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
@@ -35,6 +35,11 @@ public class TemplateService {
         return templateRepository.findById(id).orElseThrow(TemplateNotFoundException::new);
     }
 
+    // 이름으로 템플릿 조회, unique 적용함
+    public Template findByName(String name) {
+        return templateRepository.findByTemplateName(name);
+    }
+
     // 유저의 커스텀 템플릿 조회
     public List<TemplateResponseDto> findCustomTemplatesByUser(String userId) {
         Member member = memberService.findById(userId);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #88

## 📝 작업 내용

* DynamoDB에 쓰는 람다 함수 작성
* 위의 람다 함수를 연결하는 서비스 작성
* 회고를 작성한 로그 및 데이터는 DynamoDB에 다음과 같이 저장됨
![image](https://github.com/user-attachments/assets/aa4a3de0-7cc5-4d1c-8559-09ab6de64c13)
* 해당 Lambda Service에 다른 메소드를 추가하여 회고 통계 API 말고도 다른 API를 만들 수 있는 확장성을 고려함

## 💬 리뷰 요구사항 (QnA)

* 쓰는 함수는 있는데 왜 읽는 함수는 없는 걸까?
  * 트래픽이 많아질 것 같아 DynamoDB를 읽는 함수는 API Gateway로 분리할 예정입니다.
* Redis를 써도 되지 않나?
  * 해당 API가 상당한 쓰기를 유발 (**유저가 회고를 작성할 때 마다 쓰기를 수행**, Redis는 빠른 읽기에 적합)
  * 이미 RT 저장과 좋아요 저장에 대해 많은 쓰기를 사용 중 (**추후 DynamoDB로 마이그레이션 여부 생각 중**)
* **application.properties 변경되었습니다.**

### 아키텍처
![image](https://github.com/user-attachments/assets/9d39f329-09bc-480e-85c2-c1e25f71129e)
