### PR TITLE
Refactor/#92 jpa

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/CategoryRepository.java
@@ -3,8 +3,10 @@ package com.dnd.reevserver.domain.category.repository;
 import com.dnd.reevserver.domain.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     Optional<Category> findByCategoryName(String categoryName);
+    List<Category> findByCategoryNameIn(List<String> names);
 }

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface MemoCategoryRepository extends JpaRepository<MemoCategory, Long> {
     @Modifying
-    @Query("DELETE FROM MemoCategory mc WHERE mc.memo = :memo")
+    @Query("DELETE FROM MemoCategory mc " +
+            "WHERE mc.memo = :memo")
     void deleteAllByMemo(@Param("memo") Memo memo);
 }

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
@@ -7,11 +7,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface MemoCategoryRepository extends JpaRepository<MemoCategory, Long> {
-    List<MemoCategory> findByMemo(Memo memo);
-
     @Modifying
     @Query("DELETE FROM MemoCategory mc WHERE mc.memo = :memo")
     void deleteAllByMemo(@Param("memo") Memo memo);

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/MemoCategoryRepository.java
@@ -3,9 +3,16 @@ package com.dnd.reevserver.domain.category.repository;
 import com.dnd.reevserver.domain.category.entity.MemoCategory;
 import com.dnd.reevserver.domain.memo.entity.Memo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MemoCategoryRepository extends JpaRepository<MemoCategory, Long> {
     List<MemoCategory> findByMemo(Memo memo);
+
+    @Modifying
+    @Query("DELETE FROM MemoCategory mc WHERE mc.memo = :memo")
+    void deleteAllByMemo(@Param("memo") Memo memo);
 }

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/TemplateCategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/TemplateCategoryRepository.java
@@ -9,7 +9,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface TemplateCategoryRepository extends JpaRepository<TemplateCategory, Long> {
     @Modifying
-    @Query("DELETE FROM TemplateCategory tc WHERE tc.template = :template")
+    @Query("DELETE FROM TemplateCategory tc " +
+            "WHERE tc.template = :template")
     void deleteAllByTemplate(@Param("template") Template template);
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/TemplateCategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/TemplateCategoryRepository.java
@@ -3,7 +3,13 @@ package com.dnd.reevserver.domain.category.repository;
 import com.dnd.reevserver.domain.category.entity.TemplateCategory;
 import com.dnd.reevserver.domain.template.entity.Template;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TemplateCategoryRepository extends JpaRepository<TemplateCategory, Long> {
-    void deleteAllByTemplate(Template template);
+    @Modifying
+    @Query("DELETE FROM TemplateCategory tc WHERE tc.template = :template")
+    void deleteAllByTemplate(@Param("template") Template template);
+
 }

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/batch/MemoCategoryBatchRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/batch/MemoCategoryBatchRepository.java
@@ -1,0 +1,35 @@
+package com.dnd.reevserver.domain.category.repository.batch;
+
+import com.dnd.reevserver.domain.category.entity.MemoCategory;
+import com.dnd.reevserver.domain.category.entity.TemplateCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MemoCategoryBatchRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<MemoCategory> mcList){
+        LocalDateTime now = LocalDateTime.now();
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO memo_category(`category_id`, `memo_id`, `created_at`, `updated_at`) VALUES (?,?,?,?)",
+                mcList, // insert할 데이터 리스트
+                50, // 1회에 진행할 배치 사이즈
+                (ps, mc) -> {
+                    ps.setLong(1, mc.getCategory().getCategoryId());
+                    ps.setLong(2, mc.getMemo().getMemoId());
+                    ps.setTimestamp(3, Timestamp.valueOf(now));
+                    ps.setTimestamp(4, Timestamp.valueOf(now));
+                }
+
+        );
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/batch/MemoCategoryBatchRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/batch/MemoCategoryBatchRepository.java
@@ -1,7 +1,6 @@
 package com.dnd.reevserver.domain.category.repository.batch;
 
 import com.dnd.reevserver.domain.category.entity.MemoCategory;
-import com.dnd.reevserver.domain.category.entity.TemplateCategory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/batch/TemplateCategoryBatchRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/batch/TemplateCategoryBatchRepository.java
@@ -1,0 +1,35 @@
+package com.dnd.reevserver.domain.category.repository.batch;
+
+import com.dnd.reevserver.domain.category.entity.TemplateCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class TemplateCategoryBatchRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<TemplateCategory> tcList){
+        LocalDateTime now = LocalDateTime.now();
+        jdbcTemplate.batchUpdate(
+                "INSERT INTO template_category(`category_id`, `template_id`, `created_at`, `updated_at`) VALUES (?,?,?,?)",
+                tcList, // insert할 데이터 리스트
+                50, // 1회에 진행할 배치 사이즈
+                (ps, tc) -> {
+                    ps.setLong(1, tc.getCategory().getCategoryId());
+                    ps.setLong(2, tc.getTemplate().getTemplateId());
+                    // 직접 createdAt, updatedAt 설정
+                    ps.setTimestamp(3, Timestamp.valueOf(tc.getCreatedAt() != null ? tc.getCreatedAt() : now));
+                    ps.setTimestamp(4, Timestamp.valueOf(tc.getUpdatedAt() != null ? tc.getUpdatedAt() : now));
+                }
+
+        );
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/batch/TemplateCategoryBatchRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/batch/TemplateCategoryBatchRepository.java
@@ -25,9 +25,8 @@ public class TemplateCategoryBatchRepository {
                 (ps, tc) -> {
                     ps.setLong(1, tc.getCategory().getCategoryId());
                     ps.setLong(2, tc.getTemplate().getTemplateId());
-                    // 직접 createdAt, updatedAt 설정
-                    ps.setTimestamp(3, Timestamp.valueOf(tc.getCreatedAt() != null ? tc.getCreatedAt() : now));
-                    ps.setTimestamp(4, Timestamp.valueOf(tc.getUpdatedAt() != null ? tc.getUpdatedAt() : now));
+                    ps.setTimestamp(3, Timestamp.valueOf(now));
+                    ps.setTimestamp(4, Timestamp.valueOf(now));
                 }
 
         );

--- a/src/main/java/com/dnd/reevserver/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/repository/MemoRepository.java
@@ -1,11 +1,13 @@
 package com.dnd.reevserver.domain.memo.repository;
 
-import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.memo.entity.Memo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
-    List<Memo> findMemosByMember(Member member);
+    @Query("SELECT m FROM Memo m JOIN FETCH m.member JOIN FETCH m.template WHERE m.member.userId = :userId")
+    List<Memo> findMemosByMemberUserId(@Param("userId") String userId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/memo/repository/MemoRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/repository/MemoRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
-    @Query("SELECT m FROM Memo m JOIN FETCH m.member JOIN FETCH m.template WHERE m.member.userId = :userId")
+    @Query("SELECT m FROM Memo m " +
+            "JOIN FETCH m.member " +
+            "JOIN FETCH m.template " +
+            "WHERE m.member.userId = :userId")
     List<Memo> findMemosByMemberUserId(@Param("userId") String userId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
@@ -2,11 +2,9 @@ package com.dnd.reevserver.domain.memo.service;
 
 import com.dnd.reevserver.domain.category.entity.Category;
 import com.dnd.reevserver.domain.category.entity.MemoCategory;
-import com.dnd.reevserver.domain.category.entity.TemplateCategory;
 import com.dnd.reevserver.domain.category.repository.CategoryRepository;
 import com.dnd.reevserver.domain.category.repository.MemoCategoryRepository;
 import com.dnd.reevserver.domain.category.repository.batch.MemoCategoryBatchRepository;
-import com.dnd.reevserver.domain.category.service.CategoryService;
 import com.dnd.reevserver.domain.member.service.MemberService;
 import com.dnd.reevserver.domain.memo.dto.request.CreateMemoRequestDto;
 import com.dnd.reevserver.domain.memo.dto.response.MemoResponseDto;
@@ -19,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/com/dnd/reevserver/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/repository/TemplateRepository.java
@@ -1,19 +1,31 @@
 package com.dnd.reevserver.domain.template.repository;
 
-import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.template.entity.Template;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface TemplateRepository extends JpaRepository<Template, Long> {
-    @Query("SELECT t FROM Template t WHERE t.member = :member AND t.isPublic = false")
-    List<Template> findByMemberAndIsPublicFalse(@Param("member") Member member);
+    @Query("SELECT t FROM Template t " +
+            "LEFT JOIN FETCH t.templateCategories tc " +
+            "LEFT JOIN FETCH tc.category " +
+            "WHERE t.member.userId = :userId AND t.isPublic = false")
+    List<Template> findByMemberUserIdAndIsPublicFalse(@Param("userId") String userId);
 
-    @Query("SELECT t FROM Template t WHERE t.isPublic = true")
-    List<Template> findByIsPublicTrue();
+
+    @Query("SELECT t FROM Template t " +
+            "LEFT JOIN FETCH t.templateCategories tc " +
+            "LEFT JOIN FETCH tc.category " +
+            "WHERE t.isPublic = true")
+    List<Template> findByIsPublicTrueWithCategories();
+
 
     Template findByTemplateName(String templateName);
+
+    @Query("SELECT t FROM Template t LEFT JOIN FETCH t.templateCategories tc LEFT JOIN FETCH tc.category WHERE t.templateId = :id")
+    Optional<Template> findByIdWithCategories(@Param("id") Long id);
+
 }

--- a/src/main/java/com/dnd/reevserver/domain/template/repository/TemplateRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/repository/TemplateRepository.java
@@ -25,7 +25,10 @@ public interface TemplateRepository extends JpaRepository<Template, Long> {
 
     Template findByTemplateName(String templateName);
 
-    @Query("SELECT t FROM Template t LEFT JOIN FETCH t.templateCategories tc LEFT JOIN FETCH tc.category WHERE t.templateId = :id")
+    @Query("SELECT t FROM Template t " +
+            "LEFT JOIN FETCH t.templateCategories tc " +
+            "LEFT JOIN FETCH tc.category " +
+            "WHERE t.templateId = :id")
     Optional<Template> findByIdWithCategories(@Param("id") Long id);
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
@@ -45,7 +45,6 @@ public class TemplateService {
 
     // 유저의 커스텀 템플릿 조회
     public List<TemplateResponseDto> findCustomTemplatesByUser(String userId) {
-        userId = "3894991774";
         return templateRepository.findByMemberUserIdAndIsPublicFalse(userId).stream()
                 .map(t -> TemplateResponseDto.builder()
                         .templateId(t.getTemplateId())
@@ -110,7 +109,6 @@ public class TemplateService {
     // 커스텀 템플릿 추가
     @Transactional
     public void createCustomTemplate(String userId, CreateTemplateRequestDto dto) {
-        userId = "3894991774";
         Member member = memberService.findById(userId);
         Template template = Template.builder()
                 .templateName(dto.templateName())
@@ -135,7 +133,6 @@ public class TemplateService {
     // 템플릿 제목, 내용, 설명, 카테고리 수정, isPublic이 false여만 가능, true면 PublicTemplateCannotModifyException 예외 처리
     @Transactional
     public void updateTemplate(String userId, UpdateTemplateRequestDto dto) {
-        userId = "3894991774";
         Template template = findById(dto.templateId());
         if(!template.getMember().getUserId().equals(userId)){
             throw new UnauthorizedTemplateException();

--- a/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
@@ -5,7 +5,6 @@ import com.dnd.reevserver.domain.category.entity.TemplateCategory;
 import com.dnd.reevserver.domain.category.repository.CategoryRepository;
 import com.dnd.reevserver.domain.category.repository.TemplateCategoryRepository;
 import com.dnd.reevserver.domain.category.repository.batch.TemplateCategoryBatchRepository;
-import com.dnd.reevserver.domain.category.service.CategoryService;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.member.service.MemberService;
 import com.dnd.reevserver.domain.template.dto.request.CreateTemplateRequestDto;

--- a/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
@@ -2,7 +2,9 @@ package com.dnd.reevserver.domain.template.service;
 
 import com.dnd.reevserver.domain.category.entity.Category;
 import com.dnd.reevserver.domain.category.entity.TemplateCategory;
+import com.dnd.reevserver.domain.category.repository.CategoryRepository;
 import com.dnd.reevserver.domain.category.repository.TemplateCategoryRepository;
+import com.dnd.reevserver.domain.category.repository.batch.TemplateCategoryBatchRepository;
 import com.dnd.reevserver.domain.category.service.CategoryService;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.member.service.MemberService;
@@ -28,8 +30,9 @@ import java.util.stream.Collectors;
 public class TemplateService {
     private final TemplateRepository templateRepository;
     private final TemplateCategoryRepository templateCategoryRepository;
-    private final CategoryService categoryService;
+    private final TemplateCategoryBatchRepository templateCategoryBatchRepository;
     private final MemberService memberService;
+    private final CategoryRepository categoryRepository;
 
     public Template findById(Long id) {
         return templateRepository.findById(id).orElseThrow(TemplateNotFoundException::new);
@@ -107,6 +110,7 @@ public class TemplateService {
     // 커스텀 템플릿 추가
     @Transactional
     public void createCustomTemplate(String userId, CreateTemplateRequestDto dto) {
+        userId = "3894991774";
         Member member = memberService.findById(userId);
         Template template = Template.builder()
                 .templateName(dto.templateName())
@@ -118,20 +122,20 @@ public class TemplateService {
                 .build();
         templateRepository.save(template);
 
-        List<TemplateCategory> tcList = new ArrayList<>();
-        for(String categoryName : dto.categoryNames()){
-            Category category = categoryService.findByCategoryName(categoryName);
-            TemplateCategory tc = new TemplateCategory(template, category);
-            template.addTemplateCategory(tc);
-            tcList.add(tc);
-        }
-        templateCategoryRepository.saveAll(tcList);
+        // (IN 절 사용)
+        List<Category> categories = categoryRepository.findByCategoryNameIn(dto.categoryNames());
 
+        // 조회한 카테고리로 TemplateCategory 리스트 생성
+        List<TemplateCategory> tcList = categories.stream()
+                .map(category -> new TemplateCategory(template, category))
+                .collect(Collectors.toList());
+        templateCategoryBatchRepository.saveAll(tcList);
     }
 
     // 템플릿 제목, 내용, 설명, 카테고리 수정, isPublic이 false여만 가능, true면 PublicTemplateCannotModifyException 예외 처리
     @Transactional
     public void updateTemplate(String userId, UpdateTemplateRequestDto dto) {
+        userId = "3894991774";
         Template template = findById(dto.templateId());
         if(!template.getMember().getUserId().equals(userId)){
             throw new UnauthorizedTemplateException();
@@ -148,20 +152,22 @@ public class TemplateService {
         templateCategoryRepository.deleteAllByTemplate(template);
         template.clearTemplateCategory();
 
-        List<TemplateCategory> tcList = new ArrayList<>();
-        for(String categoryName : dto.categoryNames()){
-            Category category = categoryService.findByCategoryName(categoryName);
-            TemplateCategory tc = new TemplateCategory(template, category);
-            template.addTemplateCategory(tc);
-            tcList.add(tc);
-        }
-        templateCategoryRepository.saveAll(tcList);
+        // (IN 절 사용)
+        List<Category> categories = categoryRepository.findByCategoryNameIn(dto.categoryNames());
+
+        // 조회한 카테고리로 TemplateCategory 리스트 생성
+        List<TemplateCategory> tcList = categories.stream()
+                .map(category -> new TemplateCategory(template, category))
+                .collect(Collectors.toList());
+
+        templateCategoryBatchRepository.saveAll(tcList);
     }
 
     // 템플릿 삭제. isPublic이 false여만 가능, true면 PublicTemplateCannotDeleteException 예외 처리
     @Transactional
     public void deleteTemplate(Long templateId) {
         Template template = findById(templateId);
+        templateCategoryRepository.deleteAllByTemplate(template);
 
         if (template.isPublic()) {
             throw new PublicTemplateCannotDeleteException();

--- a/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
@@ -35,7 +35,7 @@ public class TemplateService {
     private final CategoryRepository categoryRepository;
 
     public Template findById(Long id) {
-        return templateRepository.findById(id).orElseThrow(TemplateNotFoundException::new);
+        return templateRepository.findByIdWithCategories(id).orElseThrow(TemplateNotFoundException::new);
     }
 
     // 이름으로 템플릿 조회, unique 적용함
@@ -45,8 +45,8 @@ public class TemplateService {
 
     // 유저의 커스텀 템플릿 조회
     public List<TemplateResponseDto> findCustomTemplatesByUser(String userId) {
-        Member member = memberService.findById(userId);
-        return templateRepository.findByMemberAndIsPublicFalse(member).stream()
+        userId = "3894991774";
+        return templateRepository.findByMemberUserIdAndIsPublicFalse(userId).stream()
                 .map(t -> TemplateResponseDto.builder()
                         .templateId(t.getTemplateId())
                         .templateName(t.getTemplateName())
@@ -67,7 +67,7 @@ public class TemplateService {
 
     // 공용 템플릿 조회
     public List<TemplateResponseDto> findPublicTemplates() {
-        return templateRepository.findByIsPublicTrue().stream()
+        return templateRepository.findByIsPublicTrueWithCategories().stream()
                 .map(
                         t -> TemplateResponseDto.builder()
                                 .templateId(t.getTemplateId())
@@ -110,6 +110,7 @@ public class TemplateService {
     // 커스텀 템플릿 추가
     @Transactional
     public void createCustomTemplate(String userId, CreateTemplateRequestDto dto) {
+        userId = "3894991774";
         Member member = memberService.findById(userId);
         Template template = Template.builder()
                 .templateName(dto.templateName())
@@ -134,6 +135,7 @@ public class TemplateService {
     // 템플릿 제목, 내용, 설명, 카테고리 수정, isPublic이 false여만 가능, true면 PublicTemplateCannotModifyException 예외 처리
     @Transactional
     public void updateTemplate(String userId, UpdateTemplateRequestDto dto) {
+        userId = "3894991774";
         Template template = findById(dto.templateId());
         if(!template.getMember().getUserId().equals(userId)){
             throw new UnauthorizedTemplateException();

--- a/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
+++ b/src/main/java/com/dnd/reevserver/domain/template/service/TemplateService.java
@@ -110,7 +110,6 @@ public class TemplateService {
     // 커스텀 템플릿 추가
     @Transactional
     public void createCustomTemplate(String userId, CreateTemplateRequestDto dto) {
-        userId = "3894991774";
         Member member = memberService.findById(userId);
         Template template = Template.builder()
                 .templateName(dto.templateName())
@@ -135,7 +134,6 @@ public class TemplateService {
     // 템플릿 제목, 내용, 설명, 카테고리 수정, isPublic이 false여만 가능, true면 PublicTemplateCannotModifyException 예외 처리
     @Transactional
     public void updateTemplate(String userId, UpdateTemplateRequestDto dto) {
-        userId = "3894991774";
         Template template = findById(dto.templateId());
         if(!template.getMember().getUserId().equals(userId)){
             throw new UnauthorizedTemplateException();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #92

## 📝 작업 내용

* 템플릿, 메모 조회 시 카테고리에 의한 N+1 문제를 JOIN FETCH 문으로 수정
* 템픒릿, 메모에 연결된 카테고리 생성 시 각각의 Insert문이 발생하던 문제를 JDBC로 해결
  * 현재 두 엔티티는 **strategy = GenerationType.IDENTITY이기에 application.properties에 설정을 추가하는 것으론 해결 불가**
  * 직접 JDBC를 이용해 벌크 Insert를 사용하도록 수정

## 💬 리뷰 요구사항 (선택 사항)

* 현재 JPA Repository에 쿼리문을 직접 작성하는 방식으로 리펙토링 하였습니다. 이 쿼리문이 너무 길어지면 QueryDsl을 사용해야 할 것 같습니다.
* jpa의 **deleteAll을 사용하실 때 @Modifying와 @Query를 사용하시지 않으시면 결국 하나씩 삭제**되기에 이에 유의 부탁드립니다.