### PR TITLE
Refactor/#99 fetch

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/controller/MemberController.java
@@ -68,4 +68,11 @@ public class MemberController {
     }
 
     // 유저의 임시글 수
+
+    @Operation(summary = "내가 속한 모임 조회")
+    @GetMapping("/group/list/{userId}")
+    public ResponseEntity<List<TeamResponseDto>> getTeamLists(@PathVariable String userId) {
+        List<TeamResponseDto> responseList = memberService.getAllGroups(userId);
+        return ResponseEntity.ok().body(responseList);
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/controller/MemberController.java
@@ -68,11 +68,4 @@ public class MemberController {
     }
 
     // 유저의 임시글 수
-
-    @Operation(summary = "내가 속한 모임 조회")
-    @GetMapping("/group/list/{userId}")
-    public ResponseEntity<List<TeamResponseDto>> getTeamLists(@PathVariable String userId) {
-        List<TeamResponseDto> responseList = memberService.getAllGroups(userId);
-        return ResponseEntity.ok().body(responseList);
-    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/service/MemberService.java
@@ -109,7 +109,6 @@ public class MemberService {
     }
 
     // 내가 속한 모임 조회
-    // todo : 유성님 이거 작업하실 건가요?
     @Transactional(readOnly = true)
     public List<TeamResponseDto> getAllGroups(String userId){
         List<Team> groups = teamRepository.findAllByUserId(userId);

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -51,5 +51,12 @@ public class RetrospectController implements RetrospectControllerDocs{
     }
 
 
+    @GetMapping("/all/{userId}")
+    public ResponseEntity<List<RetrospectResponseDto>> retrospects(@PathVariable String userId, @RequestParam(required = false) Long groupId) {
+        List<RetrospectResponseDto> retroList = retrospectService.getAllRetrospectByGruopId(userId, groupId);
+        return ResponseEntity.ok().body(retroList);
+    }
+
+
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -50,13 +50,4 @@ public class RetrospectController implements RetrospectControllerDocs{
         return ResponseEntity.ok().body(responseDto);
     }
 
-
-    @GetMapping("/all/{userId}")
-    public ResponseEntity<List<RetrospectResponseDto>> retrospects(@PathVariable String userId, @RequestParam(required = false) Long groupId) {
-        List<RetrospectResponseDto> retroList = retrospectService.getAllRetrospectByGruopId(userId, groupId);
-        return ResponseEntity.ok().body(retroList);
-    }
-
-
-
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -11,10 +11,16 @@ import java.util.List;
 
 
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
-    @Query("select r from Retrospect r where r.team.groupId = :groupId ")
+
+    @Query("select r from Retrospect r "
+        + "join fetch r.member "
+        + "join fetch r.team "
+        + "where r.team.groupId = :groupId")
     List<Retrospect> findAllByTeamId(@Param("groupId") Long groupId);
 
-    @Query("select r from Retrospect r where r.member.userId = :userId ")
+    @Query("select r from Retrospect r "
+        + "join fetch r.team "
+        + "where r.member.userId = :userId")
     List<Retrospect> findAllByUserId(@Param("userId") String userId);
 
     @Query("select count(r) from Retrospect r WHERE r.team.groupId = :groupId")

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
@@ -9,9 +9,11 @@ import java.util.List;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     @Query("select t from Team t " +
-            "join fetch t.userTeams ut " +
-            "where ut.member.userId = :userId")
+        "join fetch t.userTeams ut " +
+        "where ut.member.userId = :userId")
     List<Team> findAllByUserId(@Param("userId") String userId);
+
+
 
     @Query("select t from Team t "
         + "left join t.userTeams ut "

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
@@ -19,8 +19,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
     List<Team> findAllPopluarGroups();
 
     @Query("select distinct t from Team t " +
-        "join fetch t.teamCategories tc " +
-        "join fetch tc.category c " +
+        "left join fetch t.teamCategories tc " +
+        "left join fetch tc.category c " +
         "where c.categoryName in :categoryNames")
     List<Team> findGroupsByCategoryNames(@Param("categoryNames") List<String> categoryNames);
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
@@ -15,7 +15,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
 
     @Query("select t from Team t "
         + "left join t.userTeams ut "
-        + " group by t order by count(ut) desc")
+        + "group by t order by count(ut) desc")
     List<Team> findAllPopluarGroups();
 
     @Query("select distinct t from Team t " +

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
@@ -13,8 +13,6 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
         "where ut.member.userId = :userId")
     List<Team> findAllByUserId(@Param("userId") String userId);
 
-
-
     @Query("select t from Team t "
         + "left join t.userTeams ut "
         + "group by t order by count(ut) desc")

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepository.java
@@ -9,16 +9,18 @@ import java.util.List;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     @Query("select t from Team t " +
-            "join t.userTeams ut " +
+            "join fetch t.userTeams ut " +
             "where ut.member.userId = :userId")
     List<Team> findAllByUserId(@Param("userId") String userId);
 
-    @Query("select t from Team t left join t.userTeams ut group by t order by count(ut) desc")
+    @Query("select t from Team t "
+        + "left join t.userTeams ut "
+        + " group by t order by count(ut) desc")
     List<Team> findAllPopluarGroups();
 
     @Query("select distinct t from Team t " +
-        "join t.teamCategories tc " +
-        "join tc.category c " +
+        "join fetch t.teamCategories tc " +
+        "join fetch tc.category c " +
         "where c.categoryName in :categoryNames")
     List<Team> findGroupsByCategoryNames(@Param("categoryNames") List<String> categoryNames);
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) resolve #99

## 📝 작업 내용

> 회고와 그룹에 관해 N+1가 발생하는곳에 fetch  join을 적용하여 쿼리수를 줄였습니다. 
> 더 줄일 수 있을거 같은데 다른  방법도 있는지 찾아보겠습니다.
> userService의 내가 속한 모임 조회에서 
```java     
@Query("select t from Team t " +
       "left join fetch t.userTeams ut " +
       "left join fetch t.teamCategories tc " +
       "left join fetch tc.category " +
       "where ut.member.userId = :userId")
    List<Team> findAllByUserId(@Param("userId") String userId);
```
>로 쿼리를 작성했을 때 `MultipleBagFetchException` 이발생 하였습니다. 이에 따라 default_batch_fetch_size옵션을 적용하여 해결했습니다.
>참고 https://jojoldu.tistory.com/457

## 💬 리뷰 요구사항 (선택 사항)

> 위에 언급했듯이 Hibernate default_batch_fetch_size옵션을 사용하였기에 application.properties가 변경되었습니다.