### PR TITLE
Refactor/#98 login

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/reevserver/domain/member/service/MemberService.java
@@ -109,7 +109,6 @@ public class MemberService {
     }
 
     // 내가 속한 모임 조회
-    // todo : 유성님 이거 작업하실 건가요?
     @Transactional(readOnly = true)
     public List<TeamResponseDto> getAllGroups(String userId){
         List<Team> groups = teamRepository.findAllByUserId(userId);

--- a/src/main/java/com/dnd/reevserver/global/config/properties/TokenProperties.java
+++ b/src/main/java/com/dnd/reevserver/global/config/properties/TokenProperties.java
@@ -10,6 +10,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class TokenProperties {
     private String refreshTokenName;
     private String queryParam;
-    private int accessTokenExpirationDay;
+    private int accessTokenExpirationHour;
     private int refreshTokenExpirationDay;
 }

--- a/src/main/java/com/dnd/reevserver/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/dnd/reevserver/global/config/swagger/SwaggerConfig.java
@@ -8,11 +8,7 @@ import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@OpenAPIDefinition(
-        servers = {
-                @Server(url = "https://reevapiserver.site", description = "프로덕션 서버"),
-                @Server(url = "http://localhost:8080", description = "로컬 서버")
-        })
+@OpenAPIDefinition
 @Configuration
 public class SwaggerConfig {
 

--- a/src/main/java/com/dnd/reevserver/global/jwt/provider/JwtProvider.java
+++ b/src/main/java/com/dnd/reevserver/global/jwt/provider/JwtProvider.java
@@ -18,18 +18,18 @@ import java.util.Date;
 public class JwtProvider {
 
     private final Key key;
-    private final int accessTokenExpirationDay;
+    private final int accessTokenExpirationHour;
     private final int refreshTokenExpirationDay;
 
     public JwtProvider(ReevProperties reevProperties, TokenProperties tokenProperties) {
         String jwtSecret = reevProperties.getJwtSecret();
         this.key = Keys.hmacShaKeyFor(jwtSecret.getBytes(StandardCharsets.UTF_8));
-        accessTokenExpirationDay = tokenProperties.getAccessTokenExpirationDay();
+        accessTokenExpirationHour = tokenProperties.getAccessTokenExpirationHour();
         refreshTokenExpirationDay = tokenProperties.getRefreshTokenExpirationDay();
     }
 
     public String createAccessToken(String userId) {
-        Date expiredDate = Date.from(Instant.now().plus(accessTokenExpirationDay, ChronoUnit.DAYS));
+        Date expiredDate = Date.from(Instant.now().plus(accessTokenExpirationHour, ChronoUnit.HOURS));
         return Jwts.builder()
                 .signWith(key, SignatureAlgorithm.HS256)
                 .setSubject(userId)

--- a/src/main/java/com/dnd/reevserver/global/util/CookieUtils.java
+++ b/src/main/java/com/dnd/reevserver/global/util/CookieUtils.java
@@ -14,7 +14,6 @@ public class CookieUtils {
         return ResponseCookie.from(name, value)
                 .secure(true)
                 .sameSite("None")
-                .domain("reevapiserver.site")
                 .httpOnly(true)
                 .path("/")
                 .maxAge(maxAge)
@@ -26,7 +25,6 @@ public class CookieUtils {
                 .sameSite("None")
                 .secure(true)
                 .httpOnly(true)
-                .domain("reevapiserver.site")
                 .path("/")
                 .maxAge(maxAge)
                 .build();
@@ -39,7 +37,6 @@ public class CookieUtils {
                 .sameSite("None")
                 .secure(true)
                 .httpOnly(true)
-                .domain("reevapiserver.site")
                 .path("/")
                 .maxAge(0) // 쿠키 즉시 만료
                 .build();

--- a/src/main/java/com/dnd/reevserver/global/util/CookieUtils.java
+++ b/src/main/java/com/dnd/reevserver/global/util/CookieUtils.java
@@ -14,7 +14,7 @@ public class CookieUtils {
         return ResponseCookie.from(name, value)
                 .secure(true)
                 .sameSite("None")
-                .domain("reevserver.site")
+                .domain("reevapiserver.site")
                 .httpOnly(true)
                 .path("/")
                 .maxAge(maxAge)
@@ -26,7 +26,7 @@ public class CookieUtils {
                 .sameSite("None")
                 .secure(true)
                 .httpOnly(true)
-                .domain("reevserver.site")
+                .domain("reevapiserver.site")
                 .path("/")
                 .maxAge(maxAge)
                 .build();
@@ -39,7 +39,7 @@ public class CookieUtils {
                 .sameSite("None")
                 .secure(true)
                 .httpOnly(true)
-                .domain("reevserver.site")
+                .domain("reevapiserver.site")
                 .path("/")
                 .maxAge(0) // 쿠키 즉시 만료
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #98

## 📝 작업 내용

* 쿠키 도메인 강제 적용 삭제
* Swagger에서 백엔드 주소가 그대로 드러나는 문제 해결
* AT와 RT가 같은 값으로 생성되는 문제 해결 -> AT의 만료 시간은 3일, RT는 7일로 하여 다르게 적용

## 💬 엥? 한 게 없는데요?

* application.properties 변경되었습니다.
* 사실 원래 목적은 **vercel로 배포된 프론트엔드에 쿠키가 넘어오지 않는 문제**를 해결하기 위한 것이였으나, 쿠키가 넘어오지 않는 문제는 **프론트엔드, 백엔드 간의 도메인 불일치 문제**로 인한 것이였고, 이를 해결하려면 **.app으로 끝나고 leev인 도메인을 구입**해야 하는데 상당히 비싸네요...
* 그래서 해당 문제는 다음과 같은 방향으로 가야할 것 같습니다.
  * 프론트엔드 분들이 reev.com 등으로 배포하실 때, 백엔드의 API 주소도 현재 주소에서 api.reev.com으로 서브 도메인을 만들어 설정하는 방향
  * **Next.js를 사용한 프록시 서버를 이용해 도메인 불일치 문제를 우회하는 방법** (운영진 이지형 님의 아이디어)
  *  **AWS Amplify를 이용하여 Route 53의 도메인을 사용해 프런트엔드 배포를 진행** (운영진 이지형 님의 아이디어)
* 우분투에 스케줄링을 적용하여 로그인 문제는 생기지 않을 것 같네요.