### PR TITLE
fix : 좋아요 API의 동시성 문제를 Redis로 해결

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/like/controller/LikeController.java
+++ b/src/main/java/com/dnd/reevserver/domain/like/controller/LikeController.java
@@ -17,7 +17,6 @@ public class LikeController {
     @Operation(summary = "좋아요 추가/취소 (토글 방식)")
     @PostMapping
     public ResponseEntity<String> toggleLike(@AuthenticationPrincipal String userId, @RequestBody LikeRequestDto dto) {
-
         boolean liked = likeService.toggleLike(userId, dto);
         return ResponseEntity.ok(liked ? "Liked" : "Unliked");
     }

--- a/src/main/java/com/dnd/reevserver/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/like/repository/LikeRepository.java
@@ -2,34 +2,73 @@ package com.dnd.reevserver.domain.like.repository;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Repository;
+
+import java.util.Arrays;
 
 @Repository
 public class LikeRepository {
     @Qualifier("redisBooleanTemplate") // 특정 RedisTemplate을 지정
     private final RedisTemplate<String, Boolean> redisTemplate;
 
-    public LikeRepository(RedisTemplate<String, Boolean> redisTemplate) {
+    @Qualifier("redisIntegerTemplate")
+    private final RedisTemplate<String, Integer> redisCountTemplate; // 좋아요 개수 저장을 위한 RedisTemplate
+
+    private static final String TOGGLE_LIKE_SCRIPT =
+            "if redis.call('EXISTS', KEYS[1]) == 1 then " +
+                    "   redis.call('DEL', KEYS[1]); " +  // 좋아요 취소
+                    "   redis.call('DECR', KEYS[2]); " + // 좋아요 개수 감소
+                    "   return 0; " +
+                    "else " +
+                    "   redis.call('SET', KEYS[1], '1'); " + // 좋아요 추가
+                    "   redis.call('INCR', KEYS[2]); " + // 좋아요 개수 증가
+                    "   return 1; " +
+                    "end";
+
+    public LikeRepository(RedisTemplate<String, Boolean> redisTemplate,
+                          RedisTemplate<String, Integer> redisCountTemplate) {
         this.redisTemplate = redisTemplate;
+        this.redisCountTemplate = redisCountTemplate;
     }
 
-    // 유저가 해당 게시글에 좋아요를 눌렀는지가 키가 됨. 값은 좋아요 여부
+    // 유저가 특정 회고에 좋아요를 눌렀는지 여부를 저장하는 키
     private String getLikeKey(String userId, Long retrospectId) {
-        return userId + ":" + retrospectId;
+        return "like:" + userId + ":" + retrospectId;
     }
 
-    // 좋아요
-    public void addLike(String userId, Long retrospectId) {
-        redisTemplate.opsForValue().set(getLikeKey(userId, retrospectId), true); // 좋아요 상태 저장
+    // 특정 회고의 총 좋아요 개수를 저장하는 키
+    private String getLikeCountKey(Long retrospectId) {
+        return "like:count:" + retrospectId;
     }
 
-    // 좋아요 취소
-    public void removeLike(String userId, Long retrospectId) {
-        redisTemplate.delete(getLikeKey(userId, retrospectId)); // 좋아요 상태 삭제
+    /**
+     * 좋아요 토글 (Lua 스크립트를 이용해 원자적 연산)
+     */
+    public boolean toggleLike(String userId, Long retrospectId) {
+        String likeKey = getLikeKey(userId, retrospectId);
+        String countKey = getLikeCountKey(retrospectId);
+
+        Long result = redisTemplate.execute(
+                new DefaultRedisScript<>(TOGGLE_LIKE_SCRIPT, Long.class),
+                Arrays.asList(likeKey, countKey)
+        );
+
+        return result == 1;// 1이면 좋아요 추가, 0이면 좋아요 취소
     }
 
-    // 특정 유저가 특정 게시글에 좋아요를 눌렀는지 확인
+    /**
+     * 특정 사용자가 특정 회고에 좋아요를 눌렀는지 확인
+     */
     public boolean isLiked(String userId, Long retrospectId) {
         return Boolean.TRUE.equals(redisTemplate.hasKey(getLikeKey(userId, retrospectId)));
+    }
+
+    /**
+     * 특정 회고의 좋아요 개수 조회
+     */
+    public int getLikeCount(Long retrospectId) {
+        Integer likeCount = redisCountTemplate.opsForValue().get(getLikeCountKey(retrospectId));
+        return likeCount != null ? likeCount : 0;
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/like/service/LikeService.java
+++ b/src/main/java/com/dnd/reevserver/domain/like/service/LikeService.java
@@ -9,33 +9,28 @@ import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.retrospect.service.RetrospectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class LikeService {
     private final LikeRepository likeRepository;
     private final RetrospectService retrospectService;
-    private final AlertService alertService;
     private final MemberService memberService;
+    private final AlertService alertService;
 
-    @Transactional
-    public boolean toggleLike(String userId, LikeRequestDto dto){
+
+    // 좋아요 토글 (추가 또는 취소)
+    public boolean toggleLike(String userId, LikeRequestDto dto) {
         Long retrospectId = dto.retrospectId();
         Member member = memberService.findById(userId);
         Retrospect retrospect = retrospectService.findById(retrospectId);
-        if(likeRepository.isLiked(userId, retrospectId)){
-            likeRepository.removeLike(userId, retrospectId);
-            retrospectService.updateLikeCnt(retrospectId, false);
-            return false;
-        }
-        likeRepository.addLike(userId, retrospectId);
-        retrospectService.updateLikeCnt(retrospectId, true);
-        alertService.sendMessage(member.getName() + "님이 " + retrospect.getTitle() + "에 좋아요를 눌렀습니다. [" + retrospectId + "]");
-        return true;
+        boolean result = likeRepository.toggleLike(userId, retrospectId);
+        if(result) alertService.sendMessage(member.getName() + "님이 " + retrospect.getTitle() + "에 좋아요를 눌렀습니다. [" + retrospectId + "]");
+        return result;
     }
 
-    // 특정 유저가 특정 게시글에 좋아요를 눌렀는지 확인
+
+    // 특정 사용자가 특정 회고에 좋아요를 눌렀는지 확인
     public boolean isLiked(String userId, Long retrospectId) {
         return likeRepository.isLiked(userId, retrospectId);
     }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Retrospect.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Retrospect.java
@@ -33,16 +33,12 @@ public class Retrospect extends BaseEntity {
     @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
 
-    @Column(name = "like_count")
-    private int likeCount;
-
     @Builder
     public Retrospect(Member member, Team team, String title, String content) {
         this.member = member;
         this.team = team;
         this.title = title;
         this.content = content;
-        this.likeCount = 0;
     }
 
     @Builder
@@ -58,8 +54,6 @@ public class Retrospect extends BaseEntity {
     public void setTeam(Team team) {
         this.team = team;
     }
-
-    public void updateLikeCount(int likeCount) { this.likeCount = likeCount; }
 
     public void updateTitle(String title) {
         this.title = title;

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -1,6 +1,7 @@
 package com.dnd.reevserver.domain.retrospect.service;
 
 import com.dnd.reevserver.domain.comment.repository.CommentRepository;
+import com.dnd.reevserver.domain.like.repository.LikeRepository;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.member.exception.MemberNotFoundException;
 import com.dnd.reevserver.domain.member.service.MemberService;
@@ -32,6 +33,7 @@ public class RetrospectService {
     private final TimeStringUtil timeStringUtil;
     private final CommentRepository commentRepository;
     private final LambdaService lambdaService;
+    private final LikeRepository likeRepository;
 
     //단일회고 조회
     @Transactional(readOnly = true)
@@ -118,18 +120,14 @@ public class RetrospectService {
         return new DeleteRetrospectResponseDto(RetrospectId);
     }
 
-    // 좋아요 호출 시 사용하는 내부 메소드
-    @Transactional
-    public void updateLikeCnt(Long retrospectId, boolean isLike) {
-        Retrospect retrospect = findById(retrospectId);
-        if(isLike) retrospect.updateLikeCount(retrospect.getLikeCount() + 1);
-        else retrospect.updateLikeCount(retrospect.getLikeCount() - 1);
-    }
-
     //회고수 계산
     @Transactional(readOnly = true)
     public long countByGroupId(Long groupId) {
         return retrospectRepository.countByGroupId(groupId);
+    }
+
+    public int getLikeCount(Long retrospectId) {
+        return likeRepository.getLikeCount(retrospectId);
     }
 
     private RetrospectResponseDto convertToDto(Retrospect retrospect) {
@@ -139,7 +137,7 @@ public class RetrospectService {
                 .content(retrospect.getContent())
                 .userName(retrospect.getMember().getNickname())
                 .timeString(timeStringUtil.getTimeString(retrospect.getUpdatedAt()))
-                .likeCount(retrospect.getLikeCount())
+                .likeCount(getLikeCount(retrospect.getRetrospectId()))
                 .groupName(retrospect.getTeam() != null ? retrospect.getTeam().getGroupName() : null)
                 .groupId(retrospect.getTeam() != null ? retrospect.getTeam().getGroupId() : null)
                 .commentCount(commentRepository.countByRetrospect(retrospect))

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -4,6 +4,7 @@ import com.dnd.reevserver.domain.category.entity.Category;
 import com.dnd.reevserver.domain.category.entity.TeamCategory;
 import com.dnd.reevserver.domain.category.repository.TeamCategoryRepository;
 import com.dnd.reevserver.domain.category.service.CategoryService;
+import com.dnd.reevserver.domain.like.repository.LikeRepository;
 import com.dnd.reevserver.domain.member.entity.role.Role;
 import com.dnd.reevserver.domain.member.exception.MemberNotFoundException;
 import com.dnd.reevserver.domain.member.service.FeatureKeywordService;
@@ -41,6 +42,7 @@ public class TeamService {
     private final TimeStringUtil timeStringUtil;
     private final RetrospectRepository retrospectRepository;
     private final FeatureKeywordService featureKeywordService;
+    private final LikeRepository likeRepository;
 
     //모든 그룹조회
     @Transactional(readOnly = true)
@@ -212,6 +214,10 @@ public class TeamService {
 
     }
 
+    public int getLikeCount(Long retrospectId) {
+        return likeRepository.getLikeCount(retrospectId);
+    }
+
     private TeamResponseDto convertToDto(Team team){
         return TeamResponseDto.builder()
                 .groupId(team.getGroupId())
@@ -256,7 +262,7 @@ public class TeamService {
                 .content(retrospect.getContent())
                 .userName(retrospect.getMember().getNickname())
                 .timeString(timeStringUtil.getTimeString(retrospect.getUpdatedAt()))
-                .likeCount(retrospect.getLikeCount())
+                .likeCount(getLikeCount(retrospect.getRetrospectId()))
                 .build();
     }
 }

--- a/src/main/java/com/dnd/reevserver/global/config/redis/RedisConfig.java
+++ b/src/main/java/com/dnd/reevserver/global/config/redis/RedisConfig.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.GenericToStringSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @RequiredArgsConstructor
@@ -41,6 +42,21 @@ public class RedisConfig {
         template.setHashKeySerializer(new StringRedisSerializer());
         template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
         template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    // RedisTemplate<String, Integer> 등록
+    @Bean
+    public RedisTemplate<String, Integer> redisIntegerTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Integer> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericToStringSerializer<>(Integer.class));
+        template.setHashValueSerializer(new GenericToStringSerializer<>(Integer.class));
 
         template.afterPropertiesSet();
         return template;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #102

## 📝 작업 내용

* 회고의 like_count를 Redis가 감당하게 함
  * 이에 대한 자세한 내용은 해당 Discussions를 참고해 주세요.
  * (https://github.com/dnd-side-project/dnd-12th-10-backend/discussions/105)

## 💬 리뷰 요구사항 (선택 사항)

* 위의 Discussions을 읽어주세요.
* 노션의 application.properties가 유성님이 변경하실 때 예전의 값으로 되어있더라고요...앞으로 반영하실 때 최신본을 반영해주세요! (지금은 고쳤습니다.)