### PR TITLE
Feature/#110 group ud

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/category/repository/TeamCategoryRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/TeamCategoryRepository.java
@@ -1,7 +1,14 @@
 package com.dnd.reevserver.domain.category.repository;
 
 import com.dnd.reevserver.domain.category.entity.TeamCategory;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TeamCategoryRepository extends JpaRepository<TeamCategory, Long> {
+    @Modifying
+    @Query("delete from TeamCategory tc "
+        + "where tc.team.groupId = :groupId")
+    void deleteAllByGroupId(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/category/repository/batch/TeamCategoryBatchRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/repository/batch/TeamCategoryBatchRepository.java
@@ -1,0 +1,33 @@
+package com.dnd.reevserver.domain.category.repository.batch;
+
+import com.dnd.reevserver.domain.category.entity.TeamCategory;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamCategoryBatchRepository {
+    private final JdbcTemplate jdbcTemplate;
+
+    @Transactional
+    public void saveAll(List<TeamCategory> teamCategoryList) {
+        LocalDateTime now = LocalDateTime.now();
+        String sql = "insert into team_category (group_id, category_id, created_at, updated_at) values (?,?,?,?)";
+        jdbcTemplate.batchUpdate(sql,
+            teamCategoryList,
+            50,
+            (ps, tc) -> {
+                ps.setLong(1, tc.getTeam().getGroupId());
+                ps.setLong(2, tc.getCategory().getCategoryId());
+                ps.setTimestamp(3, Timestamp.valueOf(now));
+                ps.setTimestamp(4, Timestamp.valueOf(now));
+            }
+        );
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/category/service/TeamCategoryService.java
+++ b/src/main/java/com/dnd/reevserver/domain/category/service/TeamCategoryService.java
@@ -1,0 +1,22 @@
+package com.dnd.reevserver.domain.category.service;
+
+import com.dnd.reevserver.domain.category.entity.TeamCategory;
+import com.dnd.reevserver.domain.category.repository.TeamCategoryRepository;
+import com.dnd.reevserver.domain.category.repository.batch.TeamCategoryBatchRepository;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TeamCategoryService {
+    private final TeamCategoryRepository teamCategoryRepository;
+    private final TeamCategoryBatchRepository teamCategoryBatchRepository;
+
+    @Transactional
+    public void updateTeamCategories(Long groupId, List<TeamCategory> teamCategories) {
+        teamCategoryRepository.deleteAllByGroupId(groupId);
+        teamCategoryBatchRepository.saveAll(teamCategories);
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -56,9 +56,5 @@ public class RetrospectController implements RetrospectControllerDocs{
         return ResponseEntity.ok().body(responseDto);
     }
 
-    @GetMapping("/all/{userId}")
-    public ResponseEntity<List<RetrospectResponseDto>> retrospectTest(@PathVariable String userId, @RequestParam(required = false) Long groupId) {
-        List<RetrospectResponseDto> retroList = retrospectService.getAllRetrospectByGruopId(userId, groupId);
-        return ResponseEntity.ok().body(retroList);
-    }
+
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -50,4 +50,15 @@ public class RetrospectController implements RetrospectControllerDocs{
         return ResponseEntity.ok().body(responseDto);
     }
 
+    @GetMapping("/{userId}/{retrospectId}")
+    public ResponseEntity<RetrospectResponseDto> getRetrospectTest(@PathVariable String userId, @PathVariable Long retrospectId) {
+        RetrospectResponseDto responseDto = retrospectService.getRetrospectById(userId, retrospectId);
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @GetMapping("/all/{userId}")
+    public ResponseEntity<List<RetrospectResponseDto>> retrospectTest(@PathVariable String userId, @RequestParam(required = false) Long groupId) {
+        List<RetrospectResponseDto> retroList = retrospectService.getAllRetrospectByGruopId(userId, groupId);
+        return ResponseEntity.ok().body(retroList);
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -50,11 +50,5 @@ public class RetrospectController implements RetrospectControllerDocs{
         return ResponseEntity.ok().body(responseDto);
     }
 
-    @GetMapping("/{userId}/{retrospectId}")
-    public ResponseEntity<RetrospectResponseDto> getRetrospectTest(@PathVariable String userId, @PathVariable Long retrospectId) {
-        RetrospectResponseDto responseDto = retrospectService.getRetrospectById(userId, retrospectId);
-        return ResponseEntity.ok().body(responseDto);
-    }
-
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -5,6 +5,7 @@ import com.dnd.reevserver.domain.team.entity.Team;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
@@ -27,4 +28,9 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
     long countByGroupId(Long groupId);
 
     Optional<Retrospect> findFirstByTeam_GroupIdOrderByUpdatedAtDesc(Long groupId);
+
+    @Modifying
+    @Query("update Retrospect r set r.team = null "
+        + "where r.team.groupId = :groupId")
+    void clearTeam(@Param("groupId") Long groupId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -20,7 +20,7 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
     List<Retrospect> findAllByTeamId(@Param("groupId") Long groupId);
 
     @Query("select r from Retrospect r "
-        + "join fetch r.team "
+        + "left join fetch r.team "
         + "where r.member.userId = :userId")
     List<Retrospect> findAllByUserId(@Param("userId") String userId);
 

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
@@ -84,21 +84,5 @@ public class TeamController implements TeamControllerDocs{
         return ResponseEntity.ok().body(deleteGroupId);
     }
 
-    @PatchMapping("/{groupId}/{userId}")
-    public ResponseEntity<GroupDetailResponseDto> updateGroupInfoTest(@PathVariable String userId, @PathVariable Long groupId, @RequestBody UpdateGroupRequestDto requestDto){
-        groupService.updateGroupInfo(userId, groupId, requestDto);
-        GroupDetailResponseDto responseDto = groupService.getGroup(userId, groupId);
-        return ResponseEntity.ok().body(responseDto);
-    }
-    @GetMapping("/{groupId}/{userId}")
-    public ResponseEntity<GroupDetailResponseDto> getGroupByIdTest(@PathVariable String userId, @PathVariable Long groupId){
-        GroupDetailResponseDto response = groupService.getGroup(userId,groupId);
-        return ResponseEntity.ok().body(response);
-    }
-    @DeleteMapping("{groupId}/{userId}")
-    public ResponseEntity<Long> deleteGroupTest(@PathVariable String userId, @PathVariable Long groupId){
-        Long deleteGroupId = groupService.deleteGroup(userId, groupId);
-        return ResponseEntity.ok().body(deleteGroupId);
-    }
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
@@ -78,6 +78,12 @@ public class TeamController implements TeamControllerDocs{
         return ResponseEntity.ok().body(responseDto);
     }
 
+    @DeleteMapping("{groupId}")
+    public ResponseEntity<Long> deleteGroup(@AuthenticationPrincipal String userId, @PathVariable Long groupId){
+        Long deleteGroupId = groupService.deleteGroup(userId, groupId);
+        return ResponseEntity.ok().body(deleteGroupId);
+    }
+
     @PatchMapping("/{groupId}/{userId}")
     public ResponseEntity<GroupDetailResponseDto> updateGroupInfoTest(@PathVariable String userId, @PathVariable Long groupId, @RequestBody UpdateGroupRequestDto requestDto){
         groupService.updateGroupInfo(userId, groupId, requestDto);
@@ -88,6 +94,11 @@ public class TeamController implements TeamControllerDocs{
     public ResponseEntity<GroupDetailResponseDto> getGroupByIdTest(@PathVariable String userId, @PathVariable Long groupId){
         GroupDetailResponseDto response = groupService.getGroup(userId,groupId);
         return ResponseEntity.ok().body(response);
+    }
+    @DeleteMapping("{groupId}/{userId}")
+    public ResponseEntity<Long> deleteGroupTest(@PathVariable String userId, @PathVariable Long groupId){
+        Long deleteGroupId = groupService.deleteGroup(userId, groupId);
+        return ResponseEntity.ok().body(deleteGroupId);
     }
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
@@ -71,5 +71,23 @@ public class TeamController implements TeamControllerDocs{
         return ResponseEntity.ok().body(recommendGroup);
     }
 
+    @PatchMapping("/{groupId}")
+    public ResponseEntity<GroupDetailResponseDto> updateGroupInfo(@AuthenticationPrincipal String userId, @PathVariable Long groupId, @RequestBody UpdateGroupRequestDto requestDto){
+        groupService.updateGroupInfo(userId, groupId, requestDto);
+        GroupDetailResponseDto responseDto = groupService.getGroup(userId, groupId);
+        return ResponseEntity.ok().body(responseDto);
+    }
+
+    @PatchMapping("/{groupId}/{userId}")
+    public ResponseEntity<GroupDetailResponseDto> updateGroupInfoTest(@PathVariable String userId, @PathVariable Long groupId, @RequestBody UpdateGroupRequestDto requestDto){
+        groupService.updateGroupInfo(userId, groupId, requestDto);
+        GroupDetailResponseDto responseDto = groupService.getGroup(userId, groupId);
+        return ResponseEntity.ok().body(responseDto);
+    }
+    @GetMapping("/{groupId}/{userId}")
+    public ResponseEntity<GroupDetailResponseDto> getGroupByIdTest(@PathVariable String userId, @PathVariable Long groupId){
+        GroupDetailResponseDto response = groupService.getGroup(userId,groupId);
+        return ResponseEntity.ok().body(response);
+    }
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
@@ -18,6 +18,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -55,5 +56,8 @@ public interface TeamControllerDocs {
 
     @Operation(summary = "모임 정보 수정 API", description = "모임정보를 수정합니다.")
     public ResponseEntity<GroupDetailResponseDto> updateGroupInfo(@AuthenticationPrincipal String userId, @PathVariable Long groupId, @RequestBody UpdateGroupRequestDto requestDto);
+
+    @Operation(summary = "모임 삭제 API", description = "모임을 삭제합니다.")
+    public ResponseEntity<Long> deleteGroup(@AuthenticationPrincipal String userId, @PathVariable Long groupId);
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
@@ -5,6 +5,7 @@ import com.dnd.reevserver.domain.team.dto.request.AddTeamRequestDto;
 import com.dnd.reevserver.domain.team.dto.request.GetRecommendGroupRequestDto;
 import com.dnd.reevserver.domain.team.dto.request.JoinGroupRequestDto;
 import com.dnd.reevserver.domain.team.dto.request.LeaveGroupRequestDto;
+import com.dnd.reevserver.domain.team.dto.request.UpdateGroupRequestDto;
 import com.dnd.reevserver.domain.team.dto.response.AddFavoriteGroupResponseDto;
 import com.dnd.reevserver.domain.team.dto.response.AddTeamResponseDto;
 import com.dnd.reevserver.domain.team.dto.response.GetPopularGroupResponseDto;
@@ -18,6 +19,7 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -50,5 +52,8 @@ public interface TeamControllerDocs {
 
     @Operation(summary = "추천 모임 조회 API", description = "추천 모임을 조회합니다.")
     public ResponseEntity<List<TeamResponseDto>> getRecommendGroups(@AuthenticationPrincipal String userId);
+
+    @Operation(summary = "모임 정보 수정 API", description = "모임정보를 수정합니다.")
+    public ResponseEntity<GroupDetailResponseDto> updateGroupInfo(@AuthenticationPrincipal String userId, @PathVariable Long groupId, @RequestBody UpdateGroupRequestDto requestDto);
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/dto/request/UpdateGroupRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/dto/request/UpdateGroupRequestDto.java
@@ -1,0 +1,10 @@
+package com.dnd.reevserver.domain.team.dto.request;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record UpdateGroupRequestDto(String groupName, String description, String introduction,
+                                    Boolean isPublic, Integer maxNum, List<String> categoryNames) {
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/team/entity/Team.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/entity/Team.java
@@ -37,7 +37,7 @@ public class Team extends BaseEntity {
     @Column(name = "max_num", nullable = false)
     private int maxNum;
 
-    @OneToMany(mappedBy = "team")
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<UserTeam> userTeams = new ArrayList<>();
 
     @Column(name = "recent_act")
@@ -46,7 +46,7 @@ public class Team extends BaseEntity {
     @Column(name = "owner_id", nullable = false)
     private String ownerId;
 
-    @OneToMany(mappedBy = "team")
+    @OneToMany(mappedBy = "team", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<TeamCategory> teamCategories = new ArrayList<>();
 
     @Builder

--- a/src/main/java/com/dnd/reevserver/domain/team/entity/Team.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/entity/Team.java
@@ -70,4 +70,13 @@ public class Team extends BaseEntity {
         teamCategories.add(teamCategory);
         teamCategory.updateTeam(this);
     }
+
+    public void updateTeamInfo(String groupName, String description, String introduction,
+        Boolean isPublic, int maxNum) {
+        this.groupName = groupName;
+        this.description = description;
+        this.introduction = introduction;
+        this.isPublic = isPublic;
+        this.maxNum = maxNum;
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/exception/NotOwnerUserException.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/exception/NotOwnerUserException.java
@@ -3,7 +3,7 @@ package com.dnd.reevserver.domain.team.exception;
 import com.dnd.reevserver.global.exception.GeneralException;
 
 public class NotOwnerUserException extends GeneralException {
-    private static final String MESSAGE = "모임장이 아니라서 정보 수정이 불가능합니다.";
+    private static final String MESSAGE = "모임장이 아니라서 불가능한 동작입니다.";
 
     public NotOwnerUserException() {super(MESSAGE);}
 

--- a/src/main/java/com/dnd/reevserver/domain/team/exception/NotOwnerUserException.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/exception/NotOwnerUserException.java
@@ -1,0 +1,14 @@
+package com.dnd.reevserver.domain.team.exception;
+
+import com.dnd.reevserver.global.exception.GeneralException;
+
+public class NotOwnerUserException extends GeneralException {
+    private static final String MESSAGE = "모임장이 아니라서 정보 수정이 불가능합니다.";
+
+    public NotOwnerUserException() {super(MESSAGE);}
+
+    @Override
+    public int getStatusCode() {
+        return 403;
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -1,5 +1,7 @@
 package com.dnd.reevserver.domain.team.service;
 
+import static com.dnd.reevserver.domain.category.entity.QCategory.category;
+
 import com.dnd.reevserver.domain.category.entity.Category;
 import com.dnd.reevserver.domain.category.entity.TeamCategory;
 import com.dnd.reevserver.domain.category.exception.CategoryNotFoundException;
@@ -29,6 +31,7 @@ import com.dnd.reevserver.domain.userTeam.exception.UserGroupNotFoundException;
 import com.dnd.reevserver.domain.userTeam.repository.UserTeamRepository;
 import com.dnd.reevserver.global.util.TimeStringUtil;
 import java.util.ArrayList;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -216,13 +219,11 @@ public class TeamService {
             requestDto.maxNum());
 
         if(requestDto.categoryNames()!=null && !requestDto.categoryNames().isEmpty()){
-            List<TeamCategory> teamCategoryList = new ArrayList<>();
-            for(String categoryName : requestDto.categoryNames()){
-                Category category = categoryRepository.findByCategoryName(categoryName)
-                    .orElseThrow(CategoryNotFoundException::new);
-                TeamCategory teamCategory = new TeamCategory(team, category);
-                teamCategoryList.add(teamCategory);
-            }
+
+            List<Category> categoryList = categoryRepository.findByCategoryNameIn(requestDto.categoryNames());
+            List<TeamCategory> teamCategoryList = categoryList.stream()
+                .map(category -> new TeamCategory(team,category))
+                .toList();
             teamCategoryService.updateTeamCategories(groupId, teamCategoryList);
             team.getTeamCategories().clear();
             for (TeamCategory teamCategory : teamCategoryList) {

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -232,6 +232,19 @@ public class TeamService {
 
     }
 
+    //그룹 삭제
+    @Transactional
+    public Long deleteGroup(String userId, Long groupId) {
+        Team team = findById(groupId);
+        if(!team.getOwnerId().equals(userId)){
+            throw new NotOwnerUserException();
+        }
+        retrospectRepository.clearTeam(team.getGroupId());
+
+        teamRepository.delete(team);
+        return groupId;
+    }
+
     public Team findById(Long groupId) {
         return teamRepository.findById(groupId).orElseThrow(TeamNotFoundException::new);
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) resolve #110

## 📝 작업 내용

> 모임 수정/ 삭제를 구현하였습니다.
> 모임 삭제시 모임원이 작성한 회고가 원치 않게 삭제되는것을 방지하기 위해 team을 null처리해서 개인회고처럼 활용할 수 있게 하였습니다.

## 💬 리뷰 요구사항

> 1. TeamCategory관련해서 태웅님이 하셨던것 처럼 저도 jdbc를 이용해  벌크insert를 해보았는데 관련한 로직이 이상없는지 확인 부탁드립니다.
> 2. 모임 수정과 관련해서 맨처음에는 일부 리소스만 받아 patch로 매핑하긴했는데, 이렇게 하려다보니 카테고리 부분에서 애매한 부분이 있는거같습니다. 그룹 카테고리 수정만 따로 분리한다던가 하는것은 비효율적인것 같은데 그냥 put으로 변경되지 않는 값들도 받는게 나을까요??