### PR TITLE
Feature/#109 bookmark

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/comment/repository/CommentRepository.java
@@ -25,4 +25,6 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 
 
     int countByRetrospect(Retrospect retrospect);
+
+    void deleteAllByRetrospectRetrospectId(Long retrospectId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectController.java
@@ -4,6 +4,7 @@ import com.dnd.reevserver.domain.retrospect.dto.request.*;
 import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.DeleteRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectSingleResponseDto;
 import com.dnd.reevserver.domain.retrospect.service.RetrospectService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,8 +40,8 @@ public class RetrospectController implements RetrospectControllerDocs{
     }
 
     @PatchMapping
-    public ResponseEntity<RetrospectResponseDto> updateRetrospect(@AuthenticationPrincipal String userId, @RequestBody UpdateRetrospectRequestDto requestDto){
-        RetrospectResponseDto responseDto = retrospectService.updateRetrospect(userId, requestDto);
+    public ResponseEntity<RetrospectSingleResponseDto> updateRetrospect(@AuthenticationPrincipal String userId, @RequestBody UpdateRetrospectRequestDto requestDto){
+        RetrospectSingleResponseDto responseDto = retrospectService.updateRetrospect(userId, requestDto);
         return ResponseEntity.ok().body(responseDto);
     }
 
@@ -50,4 +51,27 @@ public class RetrospectController implements RetrospectControllerDocs{
         return ResponseEntity.ok().body(responseDto);
     }
 
+    @GetMapping("/bookmark")
+    public ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospects(@AuthenticationPrincipal String userId) {
+        List<RetrospectResponseDto> bookmarkedRetrospects = retrospectService.getBookmarkedRetrospects(userId);
+        return ResponseEntity.ok().body(bookmarkedRetrospects);
+    }
+
+    @GetMapping("/bookmark/group")
+    public ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospectsWithGroupId(@AuthenticationPrincipal String userId, @RequestParam Long groupId) {
+        List<RetrospectResponseDto> bookmarkedRetrospects = retrospectService.getBookmarkedRetrospectsWithGroupId(userId, groupId);
+        return ResponseEntity.ok().body(bookmarkedRetrospects);
+    }
+
+    @PostMapping("/bookmark")
+    public ResponseEntity<Void> insertBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto) {
+        retrospectService.insertBookmark(userId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/bookmark")
+    public ResponseEntity<Void> deleteBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto) {
+        retrospectService.deleteBookmark(userId, dto);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectControllerDocs.java
@@ -18,29 +18,29 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface RetrospectControllerDocs {
 
     @Operation(summary = "회고 목록 조회 API", description = "모든 회고들을 불러옵니다.")
-    public ResponseEntity<List<RetrospectResponseDto>> retrospect(@AuthenticationPrincipal String userId, @RequestParam Long groupId);
+    ResponseEntity<List<RetrospectResponseDto>> retrospect(@AuthenticationPrincipal String userId, @RequestParam Long groupId);
 
     @Operation(summary = "단일 회고 조회 API", description = "선택한 회고를 불러옵니다.")
-    public ResponseEntity<RetrospectResponseDto> getRetrospect(@AuthenticationPrincipal String userId, @PathVariable Long retrospectId);
+    ResponseEntity<RetrospectResponseDto> getRetrospect(@AuthenticationPrincipal String userId, @PathVariable Long retrospectId);
 
     @Operation(summary = "회고 작성 API", description = "회고를 작성합니다.")
-    public ResponseEntity<AddRetrospectResponseDto> addRetrospect(@AuthenticationPrincipal String userId, @RequestBody AddRetrospectRequestDto requestDto);
+    ResponseEntity<AddRetrospectResponseDto> addRetrospect(@AuthenticationPrincipal String userId, @RequestBody AddRetrospectRequestDto requestDto);
 
     @Operation(summary = "회고 수정 API", description = "회고를 수정합니다. 북마크 정보 없이 리턴함.")
-    public ResponseEntity<RetrospectSingleResponseDto> updateRetrospect(@AuthenticationPrincipal String userId, @RequestBody UpdateRetrospectRequestDto requestDto);
+    ResponseEntity<RetrospectSingleResponseDto> updateRetrospect(@AuthenticationPrincipal String userId, @RequestBody UpdateRetrospectRequestDto requestDto);
 
     @Operation(summary = "회고 삭제 API", description = "회고를 삭제합니다.")
-    public ResponseEntity<DeleteRetrospectResponseDto>  deleteRetrospect(@AuthenticationPrincipal String userId, @RequestBody DeleteRetrospectRequestDto requestDto);
+    ResponseEntity<DeleteRetrospectResponseDto>  deleteRetrospect(@AuthenticationPrincipal String userId, @RequestBody DeleteRetrospectRequestDto requestDto);
 
     @Operation(summary = "북마크된 유저의 회고", description = "회고 중에서 유저가 북마크한 회고들을 가져옵니다.")
-    public ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospects(@AuthenticationPrincipal String userId);
+    ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospects(@AuthenticationPrincipal String userId);
 
     @Operation(summary = "북마크된 유저의 그룹 별 회고", description = "회고 중에서 유저가 북마크한 회고들 중 groupId에 속한 회고를 가져옵니다.")
-    public ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospectsWithGroupId(@AuthenticationPrincipal String userId, @RequestParam Long groupId);
+    ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospectsWithGroupId(@AuthenticationPrincipal String userId, @RequestParam Long groupId);
 
     @Operation(summary = "북마크 추가 API", description = "해당 회고에 유저의 북마크를 추가합니다.")
-    public ResponseEntity<Void> insertBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto);
+    ResponseEntity<Void> insertBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto);
 
     @Operation(summary = "북마크 삭제 API", description = "해당 회고에 유저의 북마크를 삭제합니다.")
-    public ResponseEntity<Void> deleteBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto);
+    ResponseEntity<Void> deleteBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/controller/RetrospectControllerDocs.java
@@ -1,13 +1,10 @@
 package com.dnd.reevserver.domain.retrospect.controller;
 
-import com.dnd.reevserver.domain.retrospect.dto.request.AddRetrospectRequestDto;
-import com.dnd.reevserver.domain.retrospect.dto.request.DeleteRetrospectRequestDto;
-import com.dnd.reevserver.domain.retrospect.dto.request.GetAllGroupRetrospectRequestDto;
-import com.dnd.reevserver.domain.retrospect.dto.request.GetRetrospectRequestDto;
-import com.dnd.reevserver.domain.retrospect.dto.request.UpdateRetrospectRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.request.*;
 import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.DeleteRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectSingleResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -29,9 +26,21 @@ public interface RetrospectControllerDocs {
     @Operation(summary = "회고 작성 API", description = "회고를 작성합니다.")
     public ResponseEntity<AddRetrospectResponseDto> addRetrospect(@AuthenticationPrincipal String userId, @RequestBody AddRetrospectRequestDto requestDto);
 
-    @Operation(summary = "회고 수정 API", description = "회고를 수정합니다.")
-    public ResponseEntity<RetrospectResponseDto> updateRetrospect(@AuthenticationPrincipal String userId, @RequestBody UpdateRetrospectRequestDto requestDto);
+    @Operation(summary = "회고 수정 API", description = "회고를 수정합니다. 북마크 정보 없이 리턴함.")
+    public ResponseEntity<RetrospectSingleResponseDto> updateRetrospect(@AuthenticationPrincipal String userId, @RequestBody UpdateRetrospectRequestDto requestDto);
 
     @Operation(summary = "회고 삭제 API", description = "회고를 삭제합니다.")
     public ResponseEntity<DeleteRetrospectResponseDto>  deleteRetrospect(@AuthenticationPrincipal String userId, @RequestBody DeleteRetrospectRequestDto requestDto);
+
+    @Operation(summary = "북마크된 유저의 회고", description = "회고 중에서 유저가 북마크한 회고들을 가져옵니다.")
+    public ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospects(@AuthenticationPrincipal String userId);
+
+    @Operation(summary = "북마크된 유저의 그룹 별 회고", description = "회고 중에서 유저가 북마크한 회고들 중 groupId에 속한 회고를 가져옵니다.")
+    public ResponseEntity<List<RetrospectResponseDto>> getBookmarkedRetrospectsWithGroupId(@AuthenticationPrincipal String userId, @RequestParam Long groupId);
+
+    @Operation(summary = "북마크 추가 API", description = "해당 회고에 유저의 북마크를 추가합니다.")
+    public ResponseEntity<Void> insertBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto);
+
+    @Operation(summary = "북마크 삭제 API", description = "해당 회고에 유저의 북마크를 삭제합니다.")
+    public ResponseEntity<Void> deleteBookmark(@AuthenticationPrincipal String userId, @RequestBody BookmarkRequestDto dto);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/BookmarkRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/request/BookmarkRequestDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.retrospect.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record BookmarkRequestDto(Long retrospectId) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectResponseDto.java
@@ -5,5 +5,5 @@ import lombok.Builder;
 @Builder
 public record RetrospectResponseDto(Long retrospectId, String title, String content,
                                     String userName, String timeString, int likeCount,
-                                    int commentCount, String groupName, Long groupId) {
+                                    int commentCount, String groupName, Long groupId, boolean bookmark) {
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectResponseDto.java
@@ -5,5 +5,5 @@ import lombok.Builder;
 @Builder
 public record RetrospectResponseDto(Long retrospectId, String title, String content,
                                     String userName, String timeString, int likeCount,
-                                    int commentCount, String groupName, Long groupId, boolean bookmark) {
+                                    long commentCount, String groupName, Long groupId, boolean bookmark) {
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectSingleResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/dto/response/RetrospectSingleResponseDto.java
@@ -1,0 +1,9 @@
+package com.dnd.reevserver.domain.retrospect.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record RetrospectSingleResponseDto(Long retrospectId, String title, String content,
+                                    String userName, String timeString, int likeCount,
+                                    int commentCount, String groupName, Long groupId) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Bookmark.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Bookmark.java
@@ -1,0 +1,32 @@
+package com.dnd.reevserver.domain.retrospect.entity;
+
+import com.dnd.reevserver.domain.member.entity.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Bookmark {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bookmark_id")
+    private Long bookmarkId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "retrospect_id", nullable = false)
+    private Retrospect retrospect;
+
+    @Builder
+    public Bookmark(Member member, Retrospect retrospect){
+        this.member = member;
+        this.retrospect = retrospect;
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Retrospect.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Retrospect.java
@@ -1,6 +1,5 @@
 package com.dnd.reevserver.domain.retrospect.entity;
 
-import com.dnd.reevserver.domain.comment.entity.Comment;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.team.entity.Team;
 import com.dnd.reevserver.global.common.entity.BaseEntity;

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Retrospect.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/entity/Retrospect.java
@@ -1,5 +1,6 @@
 package com.dnd.reevserver.domain.retrospect.entity;
 
+import com.dnd.reevserver.domain.comment.entity.Comment;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.team.entity.Team;
 import com.dnd.reevserver.global.common.entity.BaseEntity;
@@ -8,6 +9,9 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -32,6 +36,10 @@ public class Retrospect extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String content;
+
+    // 북마크 연계 삭제를 위해 사용
+    @OneToMany(mappedBy = "retrospect", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Bookmark> bookmarks = new ArrayList<>();
 
     @Builder
     public Retrospect(Member member, Team team, String title, String content) {

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/exception/BookmarkAlreadyExistedException.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/exception/BookmarkAlreadyExistedException.java
@@ -1,0 +1,14 @@
+package com.dnd.reevserver.domain.retrospect.exception;
+
+import com.dnd.reevserver.global.exception.GeneralException;
+
+public class BookmarkAlreadyExistedException extends GeneralException {
+    private static final String MESSAGE = "북마크가 이미 존재합니다.";
+
+    public BookmarkAlreadyExistedException() { super(MESSAGE); }
+
+    @Override
+    public int getStatusCode() {
+        return 400;
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/exception/BookmarkMemberWrongException.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/exception/BookmarkMemberWrongException.java
@@ -1,0 +1,14 @@
+package com.dnd.reevserver.domain.retrospect.exception;
+
+import com.dnd.reevserver.global.exception.GeneralException;
+
+public class BookmarkMemberWrongException extends GeneralException {
+  private static final String MESSAGE = "북마크를 한 유저가 아닙니다.";
+
+  public BookmarkMemberWrongException() { super(MESSAGE); }
+
+  @Override
+  public int getStatusCode() {
+    return 403;
+  }
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/exception/BookmarkNotFoundException.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/exception/BookmarkNotFoundException.java
@@ -1,0 +1,14 @@
+package com.dnd.reevserver.domain.retrospect.exception;
+
+import com.dnd.reevserver.global.exception.GeneralException;
+
+public class BookmarkNotFoundException extends GeneralException {
+  private static final String MESSAGE = "북마크 ID에 해당하는 북마크가 존재하지 않습니다.";
+
+  public BookmarkNotFoundException() { super(MESSAGE); }
+
+  @Override
+  public int getStatusCode() {
+    return 404;
+  }
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/BookmarkRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/BookmarkRepository.java
@@ -3,8 +3,6 @@ package com.dnd.reevserver.domain.retrospect.repository;
 import com.dnd.reevserver.domain.retrospect.entity.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
-
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByRetrospectRetrospectIdAndMemberUserId(Long retrospectId, String userId);
     Boolean existsByRetrospectRetrospectIdAndMemberUserId(Long retrospectId, String userId);

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/BookmarkRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/BookmarkRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.retrospect.repository;
+
+import com.dnd.reevserver.domain.retrospect.entity.Bookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/BookmarkRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/BookmarkRepository.java
@@ -3,5 +3,9 @@ package com.dnd.reevserver.domain.retrospect.repository;
 import com.dnd.reevserver.domain.retrospect.entity.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+    void deleteByRetrospectRetrospectIdAndMemberUserId(Long retrospectId, String userId);
+    Boolean existsByRetrospectRetrospectIdAndMemberUserId(Long retrospectId, String userId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -27,4 +27,8 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
     long countByGroupId(Long groupId);
 
     Optional<Retrospect> findFirstByTeam_GroupIdOrderByUpdatedAtDesc(Long groupId);
+
+    @Query("SELECT r FROM Retrospect r WHERE r.retrospectId IN " +
+            "(SELECT b.retrospect.retrospectId FROM Bookmark b WHERE b.member.userId = :userId)")
+    List<Retrospect> findRetrospectsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -1,9 +1,10 @@
 package com.dnd.reevserver.domain.retrospect.repository;
 
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
-import com.querydsl.core.Tuple;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
+
+import jakarta.persistence.Tuple;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -12,17 +13,55 @@ import java.util.List;
 
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 
-    @Query("select r from Retrospect r "
-            + "join fetch r.member "
-            + "join fetch r.team "
-            + "where r.team.groupId = :groupId")
-    List<Retrospect> findAllByTeamId(@Param("groupId") Long groupId);
+    @Query("""
+    SELECT r,
+           CASE WHEN GROUP_CONCAT(b.bookmarkId) IS NOT NULL THEN true ELSE false END,
+           COUNT(c)
+    FROM Retrospect r
+    JOIN FETCH r.member m
+    JOIN FETCH r.team t
+    LEFT JOIN Bookmark b
+        ON r.retrospectId = b.retrospect.retrospectId
+    LEFT JOIN Comment c
+        ON c.retrospect.retrospectId = r.retrospectId
+    WHERE r.retrospectId = :retrospectId
+    GROUP BY r.retrospectId
+    """)
+    Optional<Tuple> findByIdWithBookmarkAndCommentCount(@Param("retrospectId") Long retrospectId);
 
+    @Query("""
+    SELECT r,
+           CASE WHEN GROUP_CONCAT(b.bookmarkId) IS NOT NULL THEN true ELSE false END,
+           COUNT(c)
+    FROM Retrospect r
+    JOIN FETCH r.member m
+    JOIN FETCH r.team t
+    LEFT JOIN Bookmark b
+        ON r.retrospectId = b.retrospect.retrospectId
+        AND b.member.userId = :userId
+    LEFT JOIN Comment c
+        ON c.retrospect.retrospectId = r.retrospectId
+    WHERE t.groupId = :groupId
+    GROUP BY r.retrospectId
+    """)
+    List<Tuple> findAllByTeamId(@Param("groupId") Long groupId, @Param("userId") String userId);
 
-    @Query("select r from Retrospect r "
-            + "join fetch r.team "
-            + "where r.member.userId = :userId")
-    List<Retrospect> findAllByUserId(@Param("userId") String userId);
+    @Query("""
+    SELECT r,
+           CASE WHEN GROUP_CONCAT(b.bookmarkId) IS NOT NULL THEN true ELSE false END AS isBookmarked,
+           COUNT(c) AS commentCount
+    FROM Retrospect r
+    JOIN FETCH r.member m
+    JOIN FETCH r.team t
+    LEFT JOIN Bookmark b
+        ON r.retrospectId = b.retrospect.retrospectId
+        AND b.member.userId = :userId
+    LEFT JOIN Comment c
+        ON r.retrospectId = c.retrospect.retrospectId
+    WHERE r.member.userId = :userId
+    GROUP BY r.retrospectId
+    """)
+    List<Tuple> findAllByUserId(@Param("userId") String userId);
 
     @Query("select count(r) from Retrospect r " +
             "WHERE r.team.groupId = :groupId")
@@ -30,16 +69,40 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 
     Optional<Retrospect> findFirstByTeam_GroupIdOrderByUpdatedAtDesc(Long groupId);
 
-    @Query("SELECT r FROM Retrospect r " +
-            "WHERE r.retrospectId IN " +
-            "(SELECT b.retrospect.retrospectId FROM Bookmark b " +
-            "WHERE b.member.userId = :userId)")
-    List<Retrospect> findRetrospectsByUserIdWithBookmarked(@Param("userId") String userId);
+    @Query("""
+    SELECT r,
+           true,
+           COUNT(c)
+    FROM Retrospect r
+    JOIN FETCH r.member m
+    JOIN FETCH r.team t
+    LEFT JOIN Bookmark b ON r.retrospectId = b.retrospect.retrospectId AND b.member.userId = :userId
+    LEFT JOIN Comment c ON r.retrospectId = c.retrospect.retrospectId
+    WHERE r.retrospectId IN (
+        SELECT b.retrospect.retrospectId
+        FROM Bookmark b
+        WHERE b.member.userId = :userId
+    )
+    GROUP BY r.retrospectId
+    """)
+    List<Tuple> findRetrospectsByUserIdWithBookmarked(@Param("userId") String userId);
 
-    @Query("SELECT r FROM Retrospect r " +
-            "WHERE r.retrospectId IN " +
-            "(SELECT b.retrospect.retrospectId FROM Bookmark b " +
-            "WHERE b.member.userId = :userId)" +
-            "AND r.team.groupId = :groupId")
-    List<Retrospect> findRetrospectsByUserIdWithBookmarkedAndGroupId(@Param("userId") String userId, @Param("groupId") Long groupId);
+    @Query("""
+    SELECT r,
+           true,
+           COUNT(c)
+    FROM Retrospect r
+    JOIN FETCH r.member m
+    JOIN FETCH r.team t
+    LEFT JOIN Bookmark b ON r.retrospectId = b.retrospect.retrospectId AND b.member.userId = :userId
+    LEFT JOIN Comment c ON r.retrospectId = c.retrospect.retrospectId
+    WHERE r.retrospectId IN (
+        SELECT b.retrospect.retrospectId
+        FROM Bookmark b
+        WHERE b.member.userId = :userId
+    )
+    AND r.team.groupId = :groupId
+    GROUP BY r.retrospectId
+    """)
+    List<Tuple> findRetrospectsByUserIdWithBookmarkedAndGroupId(@Param("userId") String userId, @Param("groupId") Long groupId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -1,7 +1,7 @@
 package com.dnd.reevserver.domain.retrospect.repository;
 
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
-import com.dnd.reevserver.domain.team.entity.Team;
+import com.querydsl.core.Tuple;
 import io.lettuce.core.dynamic.annotation.Param;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,22 +13,33 @@ import java.util.List;
 public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
 
     @Query("select r from Retrospect r "
-        + "join fetch r.member "
-        + "join fetch r.team "
-        + "where r.team.groupId = :groupId")
+            + "join fetch r.member "
+            + "join fetch r.team "
+            + "where r.team.groupId = :groupId")
     List<Retrospect> findAllByTeamId(@Param("groupId") Long groupId);
 
+
     @Query("select r from Retrospect r "
-        + "join fetch r.team "
-        + "where r.member.userId = :userId")
+            + "join fetch r.team "
+            + "where r.member.userId = :userId")
     List<Retrospect> findAllByUserId(@Param("userId") String userId);
 
-    @Query("select count(r) from Retrospect r WHERE r.team.groupId = :groupId")
+    @Query("select count(r) from Retrospect r " +
+            "WHERE r.team.groupId = :groupId")
     long countByGroupId(Long groupId);
 
     Optional<Retrospect> findFirstByTeam_GroupIdOrderByUpdatedAtDesc(Long groupId);
 
-    @Query("SELECT r FROM Retrospect r WHERE r.retrospectId IN " +
-            "(SELECT b.retrospect.retrospectId FROM Bookmark b WHERE b.member.userId = :userId)")
-    List<Retrospect> findRetrospectsByUserId(@Param("userId") Long userId);
+    @Query("SELECT r FROM Retrospect r " +
+            "WHERE r.retrospectId IN " +
+            "(SELECT b.retrospect.retrospectId FROM Bookmark b " +
+            "WHERE b.member.userId = :userId)")
+    List<Retrospect> findRetrospectsByUserIdWithBookmarked(@Param("userId") String userId);
+
+    @Query("SELECT r FROM Retrospect r " +
+            "WHERE r.retrospectId IN " +
+            "(SELECT b.retrospect.retrospectId FROM Bookmark b " +
+            "WHERE b.member.userId = :userId)" +
+            "AND r.team.groupId = :groupId")
+    List<Retrospect> findRetrospectsByUserIdWithBookmarkedAndGroupId(@Param("userId") String userId, @Param("groupId") Long groupId);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -106,7 +106,7 @@ public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
     GROUP BY r.retrospectId
     """)
     List<Tuple> findRetrospectsByUserIdWithBookmarkedAndGroupId(@Param("userId") String userId, @Param("groupId") Long groupId);
-}
+
     @Modifying
     @Query("update Retrospect r set r.team = null "
         + "where r.team.groupId = :groupId")

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -1,9 +1,9 @@
 package com.dnd.reevserver.domain.retrospect.service;
 
 import com.dnd.reevserver.domain.retrospect.dto.request.BookmarkRequestDto;
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectSingleResponseDto;
 import com.dnd.reevserver.domain.retrospect.entity.Bookmark;
-import com.dnd.reevserver.domain.retrospect.exception.BookmarkMemberWrongException;
-import com.dnd.reevserver.domain.retrospect.exception.BookmarkNotFoundException;
+import com.dnd.reevserver.domain.retrospect.exception.*;
 import com.dnd.reevserver.domain.retrospect.repository.BookmarkRepository;
 import com.dnd.reevserver.domain.comment.repository.CommentRepository;
 import com.dnd.reevserver.domain.like.repository.LikeRepository;
@@ -15,21 +15,22 @@ import com.dnd.reevserver.domain.retrospect.dto.response.AddRetrospectResponseDt
 import com.dnd.reevserver.domain.retrospect.dto.response.DeleteRetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
-import com.dnd.reevserver.domain.retrospect.exception.RetrospectAuthorException;
-import com.dnd.reevserver.domain.retrospect.exception.RetrospectNotFoundException;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
 import com.dnd.reevserver.domain.statistics.service.LambdaService;
 import com.dnd.reevserver.domain.team.entity.Team;
 import com.dnd.reevserver.domain.team.service.TeamService;
 import com.dnd.reevserver.global.util.TimeStringUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import jakarta.persistence.Tuple;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class RetrospectService {
 
     private final RetrospectRepository retrospectRepository;
@@ -44,36 +45,49 @@ public class RetrospectService {
     //단일회고 조회
     @Transactional(readOnly = true)
     public RetrospectResponseDto getRetrospectById(String userId, Long retrospectId) {
+        userId = "3894991774";
         if(userId.isEmpty()) {
             throw new MemberNotFoundException();
         }
-        Retrospect retrospect = findById(retrospectId);
-        return convertToDto(retrospect);
+        Tuple tuple = retrospectRepository.findByIdWithBookmarkAndCommentCount(retrospectId).orElseThrow(RetrospectNotFoundException::new);
+
+        Retrospect retrospect = tuple.get(0, Retrospect.class); // 첫 번째 값: Retrospect 객체
+        boolean isBookmarked = tuple.get(1, Boolean.class); // 두 번째 값: 북마크 여부
+        long commentCount = tuple.get(2, Long.class); // 세 번째 값: 댓글 수
+
+        return convertToDto(retrospect, isBookmarked, commentCount);
     }
 
     //회고 목록 조회
     @Transactional(readOnly = true)
     public List<RetrospectResponseDto> getAllRetrospectByGruopId(String userId, Long groupId) {
+        userId = "3894991774";
         if(userId.isEmpty()) {
             throw new MemberNotFoundException();
         }
         if(groupId!=null) {
-            List<Retrospect> list = retrospectRepository.findAllByTeamId(groupId);
+            List<Tuple> list = retrospectRepository.findAllByTeamId(groupId, userId);
             return list.stream()
-                .map(this::convertToDto)
+                .map(tuple -> convertToDto(
+                        tuple.get(0, Retrospect.class),
+                        tuple.get(1, Boolean.class),
+                        tuple.get(2, Long.class)))
                 .toList();
         }
 
-        List<Retrospect> list = retrospectRepository.findAllByUserId(userId);
+        List<Tuple> list = retrospectRepository.findAllByUserId(userId);
         return list.stream()
-                .map(this::convertToDto)
+                .map(tuple -> convertToDto(
+                        tuple.get(0, Retrospect.class),
+                        tuple.get(1, Boolean.class),
+                        tuple.get(2, Long.class)))
                 .toList();
     }
-
 
     //회고 작성
     @Transactional
     public AddRetrospectResponseDto addRetrospect(String userId, AddRetrospectRequestDto requestDto) {
+        userId = "3894991774";
         Member member = memberService.findById(userId);
         if(requestDto.groupId()!=null) {
             Team team = teamService.findById(requestDto.groupId());
@@ -98,7 +112,6 @@ public class RetrospectService {
         lambdaService.writeStatistics(userId);
 
         return new AddRetrospectResponseDto(retrospect.getRetrospectId());
-
     }
 
     public Retrospect findById(Long retrospectId) {
@@ -106,24 +119,27 @@ public class RetrospectService {
     }
 
     @Transactional
-    public RetrospectResponseDto updateRetrospect(String userId, UpdateRetrospectRequestDto requestDto) {
+    public RetrospectSingleResponseDto updateRetrospect(String userId, UpdateRetrospectRequestDto requestDto) {
+        userId = "3894991774";
         Retrospect retrospect = findById(requestDto.retrospectId());
         if(!retrospect.getMember().getUserId().equals(userId)){
             throw new RetrospectAuthorException();
         }
         retrospect.updateRetrospect(requestDto.title(), requestDto.content());
-        return convertToDto(retrospect);
+        return convertToSingleDto(retrospect);
     }
 
     @Transactional
     public DeleteRetrospectResponseDto deleteRetrospect(String userId, DeleteRetrospectRequestDto requestDto) {
+        userId = "3894991774";
         Retrospect retrospect = findById(requestDto.retrospectId());
         if(!retrospect.getMember().getUserId().equals(userId)){
             throw new RetrospectAuthorException();
         }
-        long RetrospectId = retrospect.getRetrospectId();
+        long retrospectId = retrospect.getRetrospectId();
+        commentRepository.deleteAllByRetrospectRetrospectId(retrospectId);
         retrospectRepository.delete(retrospect);
-        return new DeleteRetrospectResponseDto(RetrospectId);
+        return new DeleteRetrospectResponseDto(retrospectId);
     }
 
     //회고수 계산
@@ -138,17 +154,32 @@ public class RetrospectService {
 
     // 회원의 북마크된 전체 회고 조회
     public List<RetrospectResponseDto> getBookmarkedRetrospects(String userId){
-        return retrospectRepository.findRetrospectsByUserIdWithBookmarked(userId).stream().map(this::convertToDto).toList();
+        userId = "3894991774";
+        return retrospectRepository.findRetrospectsByUserIdWithBookmarked(userId).stream()
+                .map(tuple -> convertToDto(
+                        tuple.get(0, Retrospect.class),
+                        tuple.get(1, Boolean.class),
+                        tuple.get(2, Long.class)))
+                .toList();
     }
 
     // 회원의 북마크된 그룹 별 회고 조회
     public List<RetrospectResponseDto> getBookmarkedRetrospectsWithGroupId(String userId, Long groupId){
-        return retrospectRepository.findRetrospectsByUserIdWithBookmarkedAndGroupId(userId, groupId).stream().map(this::convertToDto).toList();
+        userId = "3894991774";
+        return retrospectRepository.findRetrospectsByUserIdWithBookmarkedAndGroupId(userId, groupId).stream()
+                .map(tuple -> convertToDto(
+                        tuple.get(0, Retrospect.class),
+                        tuple.get(1, Boolean.class),
+                        tuple.get(2, Long.class)))
+                .toList();
     }
 
     // 북마크 기능 (insert)
     @Transactional
     public void insertBookmark(String userId, BookmarkRequestDto dto){
+        userId = "3894991774";
+        if(bookmarkRepository.existsByRetrospectRetrospectIdAndMemberUserId(dto.retrospectId(), userId))
+            throw new BookmarkAlreadyExistedException();
         bookmarkRepository.save(Bookmark.builder()
                 .member(memberService.findById(userId))
                 .retrospect(findById(dto.retrospectId()))
@@ -158,15 +189,27 @@ public class RetrospectService {
     // 북마크 취소 (delete)
     @Transactional
     public void deleteBookmark(String userId, BookmarkRequestDto dto){
-        Bookmark bookmark = bookmarkRepository.findById(dto.retrospectId()).orElseThrow(BookmarkNotFoundException::new);
-        if(!bookmark.getMember().getUserId().equals(userId)){
-            throw new BookmarkMemberWrongException();
-        }
-        bookmarkRepository.delete(bookmark);
+        userId = "3894991774";
+        bookmarkRepository.deleteByRetrospectRetrospectIdAndMemberUserId(dto.retrospectId(), userId);
     }
 
-    private RetrospectResponseDto convertToDto(Retrospect retrospect) {
+    private RetrospectResponseDto convertToDto(Retrospect retrospect, boolean isBookmarked, long commentCnt) {
         return RetrospectResponseDto.builder()
+                .retrospectId(retrospect.getRetrospectId())
+                .title(retrospect.getTitle())
+                .content(retrospect.getContent())
+                .userName(retrospect.getMember().getNickname())
+                .timeString(timeStringUtil.getTimeString(retrospect.getUpdatedAt()))
+                .likeCount(getLikeCount(retrospect.getRetrospectId()))
+                .groupName(retrospect.getTeam() != null ? retrospect.getTeam().getGroupName() : null)
+                .groupId(retrospect.getTeam() != null ? retrospect.getTeam().getGroupId() : null)
+                .commentCount(commentCnt)
+                .bookmark(isBookmarked)
+                .build();
+    }
+
+    private RetrospectSingleResponseDto convertToSingleDto(Retrospect retrospect) {
+        return RetrospectSingleResponseDto.builder()
                 .retrospectId(retrospect.getRetrospectId())
                 .title(retrospect.getTitle())
                 .content(retrospect.getContent())

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -45,7 +45,6 @@ public class RetrospectService {
     //단일회고 조회
     @Transactional(readOnly = true)
     public RetrospectResponseDto getRetrospectById(String userId, Long retrospectId) {
-        userId = "3894991774";
         if(userId.isEmpty()) {
             throw new MemberNotFoundException();
         }
@@ -61,7 +60,6 @@ public class RetrospectService {
     //회고 목록 조회
     @Transactional(readOnly = true)
     public List<RetrospectResponseDto> getAllRetrospectByGruopId(String userId, Long groupId) {
-        userId = "3894991774";
         if(userId.isEmpty()) {
             throw new MemberNotFoundException();
         }
@@ -87,7 +85,6 @@ public class RetrospectService {
     //회고 작성
     @Transactional
     public AddRetrospectResponseDto addRetrospect(String userId, AddRetrospectRequestDto requestDto) {
-        userId = "3894991774";
         Member member = memberService.findById(userId);
         if(requestDto.groupId()!=null) {
             Team team = teamService.findById(requestDto.groupId());
@@ -120,7 +117,6 @@ public class RetrospectService {
 
     @Transactional
     public RetrospectSingleResponseDto updateRetrospect(String userId, UpdateRetrospectRequestDto requestDto) {
-        userId = "3894991774";
         Retrospect retrospect = findById(requestDto.retrospectId());
         if(!retrospect.getMember().getUserId().equals(userId)){
             throw new RetrospectAuthorException();
@@ -131,7 +127,6 @@ public class RetrospectService {
 
     @Transactional
     public DeleteRetrospectResponseDto deleteRetrospect(String userId, DeleteRetrospectRequestDto requestDto) {
-        userId = "3894991774";
         Retrospect retrospect = findById(requestDto.retrospectId());
         if(!retrospect.getMember().getUserId().equals(userId)){
             throw new RetrospectAuthorException();
@@ -154,7 +149,6 @@ public class RetrospectService {
 
     // 회원의 북마크된 전체 회고 조회
     public List<RetrospectResponseDto> getBookmarkedRetrospects(String userId){
-        userId = "3894991774";
         return retrospectRepository.findRetrospectsByUserIdWithBookmarked(userId).stream()
                 .map(tuple -> convertToDto(
                         tuple.get(0, Retrospect.class),
@@ -165,7 +159,6 @@ public class RetrospectService {
 
     // 회원의 북마크된 그룹 별 회고 조회
     public List<RetrospectResponseDto> getBookmarkedRetrospectsWithGroupId(String userId, Long groupId){
-        userId = "3894991774";
         return retrospectRepository.findRetrospectsByUserIdWithBookmarkedAndGroupId(userId, groupId).stream()
                 .map(tuple -> convertToDto(
                         tuple.get(0, Retrospect.class),
@@ -177,7 +170,6 @@ public class RetrospectService {
     // 북마크 기능 (insert)
     @Transactional
     public void insertBookmark(String userId, BookmarkRequestDto dto){
-        userId = "3894991774";
         if(bookmarkRepository.existsByRetrospectRetrospectIdAndMemberUserId(dto.retrospectId(), userId))
             throw new BookmarkAlreadyExistedException();
         bookmarkRepository.save(Bookmark.builder()
@@ -189,7 +181,6 @@ public class RetrospectService {
     // 북마크 취소 (delete)
     @Transactional
     public void deleteBookmark(String userId, BookmarkRequestDto dto){
-        userId = "3894991774";
         bookmarkRepository.deleteByRetrospectRetrospectIdAndMemberUserId(dto.retrospectId(), userId);
     }
 

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -132,21 +132,19 @@ public class RetrospectService {
         return retrospectRepository.countByGroupId(groupId);
     }
 
-    @Transactional(readOnly = true)
     public int getLikeCount(Long retrospectId) {
         return likeRepository.getLikeCount(retrospectId);
     }
 
     // 회원의 북마크된 전체 회고 조회
-//    public List<RetrospectResponseDto> getBookmarkedRetrospects(String userId){
-//        // user의 북마크 리스트
-//        // 그 리스트 중 retrospectId 추출, in절로 retrospect 가져옴
-//
-//    }
+    public List<RetrospectResponseDto> getBookmarkedRetrospects(String userId){
+        return retrospectRepository.findRetrospectsByUserIdWithBookmarked(userId).stream().map(this::convertToDto).toList();
+    }
 
     // 회원의 북마크된 그룹 별 회고 조회
-
-    // 해당 회고가 북마크되었는지 확인 : DTO로도 해도 될 듯
+    public List<RetrospectResponseDto> getBookmarkedRetrospectsWithGroupId(String userId, Long groupId){
+        return retrospectRepository.findRetrospectsByUserIdWithBookmarkedAndGroupId(userId, groupId).stream().map(this::convertToDto).toList();
+    }
 
     // 북마크 기능 (insert)
     @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #109

## 📝 작업 내용

* 북마크 테이블 생성
* 회고의 조회 SQL문 최적화
  * Retrospect 대신 Tuple 사용, DTO의 Comment 개수 탐색과 유저의 북마크 여부도 Retrospect화 함께 탐색하도록 함
* DTO에 북마크 여부 추가
  * 모든 탐색문엔 북마크 여부가 추가된 RetrospectResponseDto 사용
  * 업데이트엔 북마크 여부가 없는 RetrospectSingleResponseDto 사용

## 💬 리뷰 요구사항 (선택 사항)

* 코드 리뷰 하실 때 "북마크 기능 구현 및 쿼리 최적화"만 보시면 됩니다. 이전은 중간 저장이에요.
* 유성님이 RetrospectRepository에 작성하신 업데이트 문이 없을 텐데 충돌 해결한 부분에 넣어두었습니다.
* RetrospectRepository의 쿼리문을 보면 상당히 길고 복잡합니다. 이거는 QueryDsl을 사용하는 것이 옳을까요?