### PR TITLE
refactor : actions가 EC2에 ssh로 접근하는 것 대신 CodeDeploy를 트리거시키게 함

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,22 +64,12 @@ jobs:
       - name: Docker push
         run: docker push ${{ steps.login-ecr.outputs.registry }}/reev-server:latest
 
-      # 열 번째 단계: SSH를 통해 EC2 인스턴스에 접속합니다. 이는 원격 서버에 접근하여 명령을 실행하기 위한 단계입니다.
-      - name: ssh
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ${{ secrets.EC2_USERNAME }}
-          key: ${{ secrets.EC2_PRIVATE_KEY }}
-          script_stop: true
-          script: |
-            # 현재 실행 중인 Docker 컨테이너를 중지합니다. 서버가 중지되어도 오류를 무시하도록 '|| true'를 추가했습니다.
-            docker stop reev-server || true
-            # 중지된 Docker 컨테이너를 삭제합니다. 이미 컨테이너가 없더라도 오류를 무시하도록 '|| true'를 추가했습니다.
-            docker rm reev-server || true
-            # 사용하지 않는 이미지를 삭제합니다.
-            docker image prune -a -f
-            # ECR로부터 최신 Docker 이미지를 가져옵니다.
-            docker pull ${{ steps.login-ecr.outputs.registry }}/reev-server:latest
-            # 새로운 Docker 컨테이너를 실행합니다. 8080 포트를 매핑하여 외부에서 접근할 수 있도록 설정했습니다.
-            docker run -d --name reev-server -p 80:8080 ${{ steps.login-ecr.outputs.registry }}/reev-server:latest
+      # 열 번째 단계: CodeDeploy를 이용해서 블루/그린 배포를 수행합니다. EC2 내에서 수행할 스크립트는 S3의 app-bundle.zip 안 start.sh에 존재합니다.
+      - name: Trigger CodeDeploy Deployment
+        run: |
+          aws deploy create-deployment \
+            --application-name ReevAppCodeDeploy \
+            --deployment-group-name AppDeploymentGroup \
+            --s3-location bucket=${{ secrets.S3_BUCKET_NAME }},key=app-bundle.zip,bundleType=zip \
+            --file-exists-behavior OVERWRITE \
+            --region ap-northeast-2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Trigger CodeDeploy Deployment
         run: |
           aws deploy create-deployment \
-            --application-name ReevAppCodeDeploy \
+            --application-name Reev-CodeDeploy \
             --deployment-group-name AppDeploymentGroup \
             --s3-location bucket=${{ secrets.S3_BUCKET_NAME }},key=app-bundle.zip,bundleType=zip \
             --file-exists-behavior OVERWRITE \


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #126 

## 📝 작업 내용

* 기존 방식은 EC2의 ssh에 actions가 직접 접근해서 스크립트를 실행시키는 방식이였습니다.
  * 이 방식은 간편하지만 가변적인 IP를 가진 actions가 EC2에 접속하기 위해 EC2의 22포트 (ssh 포트)를 0.0.0.0/0, 즉 전체에게 열어야 하기에 크나큰 보안 문제가 생길 수 있습니다.
* 원래는 그대로 둬도 되지만, Reev의 서비스를 시작하면 이러한 부분에서 문제가 생길 수 있기에 이렇게 조치합니다.
* **CodeDeploy에서 S3에 저장된 start.sh를 실행**시키는 방향으로 바꾸었고, 이 경우 EC2의 22포트를 특정 IP (저희 IP만)에만 열어도 되기에 문제가 발생하지 않게 됩니다.

## 💬 리뷰 요구사항 (선택 사항)

* 큰 리뷰 사항은 없지만, main으로 push 후 실행이 안되면 바로 조치해야 하기에 부득이하게 main 브런치에서 작업할 수 있습니다. 양해 부탁드립니다.