### PR TITLE
Feature/#136 통합검색 전체

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.jpa.repository.Query;
 import java.util.List;
 
 
-public interface RetrospectRepository extends JpaRepository<Retrospect, Long> {
+public interface RetrospectRepository extends JpaRepository<Retrospect, Long>, RetrospectRepositoryCustom {
 
     @Query("""
     SELECT

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepositoryCustom.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.dnd.reevserver.domain.retrospect.repository;
+
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import java.util.List;
+
+public interface RetrospectRepositoryCustom {
+    List<Retrospect> searchForKeyword(String keyword);
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepositoryCustomImpl.java
@@ -1,0 +1,55 @@
+package com.dnd.reevserver.domain.retrospect.repository;
+
+import static org.springframework.util.StringUtils.hasText;
+import static com.dnd.reevserver.domain.retrospect.entity.QRetrospect.retrospect;
+
+import com.dnd.reevserver.domain.retrospect.entity.QRetrospect;
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class RetrospectRepositoryCustomImpl implements RetrospectRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Retrospect> searchForKeyword(String keyword) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        BooleanExpression titleCondition = containTitle(keyword);
+        if(titleCondition != null) {
+            builder.or(titleCondition);
+        }
+
+        BooleanExpression contentCondition = containContent(keyword);
+        if(contentCondition != null) {
+            builder.or(contentCondition);
+        }
+
+        return queryFactory
+            .select(retrospect)
+            .from(retrospect)
+            .where(builder)
+            .fetch();
+    }
+
+    //제목에 포함
+    private BooleanExpression containTitle(String keyword){
+        if(!hasText(keyword)){
+            return null;
+        }
+        return retrospect.title.containsIgnoreCase(keyword);
+    }
+
+    //내용에 포함
+    private BooleanExpression containContent(String keyword){
+        if(!hasText(keyword)){
+            return null;
+        }
+        return retrospect.content.containsIgnoreCase(keyword);
+    }
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -18,6 +18,7 @@ import com.dnd.reevserver.domain.member.service.MemberService;
 import com.dnd.reevserver.domain.retrospect.dto.request.*;
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
+import com.dnd.reevserver.domain.search.dto.response.SearchRetrospectResponseDto;
 import com.dnd.reevserver.domain.statistics.service.StatisticsService;
 import com.dnd.reevserver.domain.team.entity.Team;
 import com.dnd.reevserver.domain.team.service.TeamService;
@@ -279,5 +280,14 @@ public class RetrospectService {
                 .commentCount(commentRepository.countByRetrospect(retrospect))
                 .categories(categoriesName)
                 .build();
+    }
+
+    private SearchRetrospectResponseDto convertToRetrospectResponse(Retrospect retrospect){
+        return SearchRetrospectResponseDto.builder()
+            .retrospectId(retrospect.getRetrospectId())
+            .title(retrospect.getTitle())
+            .userName(retrospect.getMember().getNickname())
+            .timeString(timeStringUtil.getTimeString(retrospect.getUpdatedAt()))
+            .build();
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -208,6 +208,16 @@ public class RetrospectService {
         return retrospectRepository.countByGroupId(groupId);
     }
 
+    //통합검색에서 검색
+    @Transactional(readOnly = true)
+    public List<SearchRetrospectResponseDto> searchForKeyword(String keyword){
+        List<Retrospect> retrospects = retrospectRepository.searchForKeyword(keyword);
+        return retrospects.stream()
+            .map(this::convertToRetrospectResponse)
+            .toList();
+    }
+
+
     public int getLikeCount(Long retrospectId) {
         return likeRepository.getLikeCount(retrospectId);
     }

--- a/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
@@ -19,8 +19,8 @@ public class SearchController {
     private final SearchService searchService;
 
     @GetMapping
-    public ResponseEntity<?> search (@RequestParam(required = false) String keyword){
-        List<SearchAllResponseDto> response = searchService.searchAll(keyword);
-        return ResponseEntity.ok().body(null);
+    public ResponseEntity<SearchAllResponseDto> search (@RequestParam(required = false) String keyword){
+        SearchAllResponseDto response = searchService.searchAll(keyword);
+        return ResponseEntity.ok().body(response);
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
@@ -1,0 +1,26 @@
+package com.dnd.reevserver.domain.search.controller;
+
+import com.dnd.reevserver.domain.search.dto.response.SearchAllResponseDto;
+import com.dnd.reevserver.domain.search.service.SearchService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @GetMapping
+    public ResponseEntity<?> search (@RequestParam(required = false) String keyword){
+        List<SearchAllResponseDto> response = searchService.searchAll(keyword);
+        return ResponseEntity.ok().body(null);
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/search/controller/SearchControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/controller/SearchControllerDocs.java
@@ -1,0 +1,17 @@
+package com.dnd.reevserver.domain.search.controller;
+
+import com.dnd.reevserver.domain.search.dto.response.SearchAllResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "통합검색 API", description = "통합검색과 관련한 API입니다.")
+public interface SearchControllerDocs {
+
+    @Operation(summary = "통합 검색 API", description = "통합 검색을 수행합니다.")
+    ResponseEntity<SearchAllResponseDto> search (@Parameter(name = "keyword",
+        description = "회고 제목이나 내용에 포함될 경우, 그룹 제목이나 한줄소개에 포함될 경우") @RequestParam(required = false) String keyword);
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/search/dto/response/SearchAllResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/dto/response/SearchAllResponseDto.java
@@ -1,0 +1,9 @@
+package com.dnd.reevserver.domain.search.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record SearchAllResponseDto(List<SearchGroupResponseDto> groups, List<SearchRetrospectResponseDto> retrospects) {
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/search/dto/response/SearchGroupResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/dto/response/SearchGroupResponseDto.java
@@ -1,0 +1,9 @@
+package com.dnd.reevserver.domain.search.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SearchGroupResponseDto(Long groupId, String groupName, String introduction,
+                                     Integer userCount, Long retrospectCount) {
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/search/dto/response/SearchRetrospectResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/dto/response/SearchRetrospectResponseDto.java
@@ -1,0 +1,9 @@
+package com.dnd.reevserver.domain.search.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record SearchRetrospectResponseDto(Long retrospectId, String title,
+                                          String userName, String timeString) {
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
@@ -1,0 +1,37 @@
+package com.dnd.reevserver.domain.search.service;
+
+import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
+import com.dnd.reevserver.domain.retrospect.service.RetrospectService;
+import com.dnd.reevserver.domain.search.dto.response.SearchAllResponseDto;
+import com.dnd.reevserver.domain.search.dto.response.SearchGroupResponseDto;
+import com.dnd.reevserver.domain.search.dto.response.SearchRetrospectResponseDto;
+import com.dnd.reevserver.domain.team.dto.response.GroupDetailResponseDto;
+import com.dnd.reevserver.domain.team.entity.Team;
+import com.dnd.reevserver.domain.team.service.TeamService;
+import com.dnd.reevserver.global.util.TimeStringUtil;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+
+    private final TeamService teamService;
+    private final RetrospectService retrospectService;
+    private final TimeStringUtil timeStringUtil;
+
+    @Transactional(readOnly = true)
+    public List<SearchAllResponseDto> searchAll(String keyword){
+        List<SearchGroupResponseDto> groups = teamService.searchForKeyword(keyword);
+        List<SearchRetrospectResponseDto> retrospects = retrospectService.searchForKeyword(keyword);
+
+    }
+
+
+
+
+
+}

--- a/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
@@ -24,14 +24,11 @@ public class SearchService {
     private final TimeStringUtil timeStringUtil;
 
     @Transactional(readOnly = true)
-    public List<SearchAllResponseDto> searchAll(String keyword){
+    public SearchAllResponseDto searchAll(String keyword){
         List<SearchGroupResponseDto> groups = teamService.searchForKeyword(keyword);
         List<SearchRetrospectResponseDto> retrospects = retrospectService.searchForKeyword(keyword);
-
+        return new SearchAllResponseDto(groups, retrospects);
     }
-
-
-
 
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustom.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface TeamRepositoryCustom {
     List<Team> search(GroupSearchCondition condition);
+    List<Team> searchForKeyword(String keyword);
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustomImpl.java
@@ -39,7 +39,7 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
         BooleanBuilder builder = new BooleanBuilder();
 
         BooleanExpression titleCondition = containTitle(keyword);
-        if (titleCondition != null) {
+        if(titleCondition != null) {
             builder.or(titleCondition);
         }
 

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustomImpl.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustomImpl.java
@@ -7,6 +7,7 @@ import static com.dnd.reevserver.domain.category.entity.QTeamCategory.teamCatego
 import com.dnd.reevserver.domain.category.entity.QTeamCategory;
 import com.dnd.reevserver.domain.team.dto.request.GroupSearchCondition;
 import com.dnd.reevserver.domain.team.entity.Team;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -32,6 +33,29 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
 
     }
 
+
+    @Override
+    public List<Team> searchForKeyword(String keyword){
+        BooleanBuilder builder = new BooleanBuilder();
+
+        BooleanExpression titleCondition = containTitle(keyword);
+        if (titleCondition != null) {
+            builder.or(titleCondition);
+        }
+
+        BooleanExpression introductionCondition = containIntroduction(keyword);
+        if (introductionCondition != null) {
+            builder.or(introductionCondition);
+        }
+
+        return queryFactory
+            .select(team)
+            .from(team)
+            .where(builder)
+            .fetch();
+    }
+
+    //제목에 포함
     private BooleanExpression containTitle(String title){
         if(!hasText(title)){
             return null;
@@ -40,6 +64,7 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
 
     }
 
+    //카테고리 포함
     private BooleanExpression categoryIn(List<String> categories) {
         if(categories == null || categories.isEmpty()) {
             return null;
@@ -51,6 +76,14 @@ public class TeamRepositoryCustomImpl implements TeamRepositoryCustom {
                 .from(tc)
                 .where(tc.category.categoryName.in(categories))
         );
+    }
 
+
+    //한줄소개에 있는지
+    private BooleanExpression containIntroduction(String keyword){
+        if(!hasText(keyword)){
+            return null;
+        }
+        return team.introduction.containsIgnoreCase(keyword);
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -14,6 +14,7 @@ import com.dnd.reevserver.domain.member.service.FeatureKeywordService;
 import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
+import com.dnd.reevserver.domain.search.dto.response.SearchGroupResponseDto;
 import com.dnd.reevserver.domain.team.dto.request.*;
 import com.dnd.reevserver.domain.team.dto.response.*;
 import com.dnd.reevserver.domain.team.entity.Team;
@@ -262,6 +263,16 @@ public class TeamService {
 
     }
 
+
+    //통합검색에서 검색
+    @Transactional(readOnly = true)
+    public List<SearchGroupResponseDto> searchForKeyword(String keyword){
+        List<Team> groups = teamRepository.searchForKeyword(keyword);
+        return groups.stream()
+            .map(this::convertToGroupResponse)
+            .toList();
+    }
+
     public Team findById(Long groupId) {
         return teamRepository.findById(groupId).orElseThrow(TeamNotFoundException::new);
     }
@@ -336,6 +347,16 @@ public class TeamService {
                 .likeCount(getLikeCount(retrospect.getRetrospectId()))
                 .categories(retrospectRepository.findCategoryNamesByRetrospectId(retrospect.getRetrospectId()))
                 .build();
+    }
+
+    private SearchGroupResponseDto convertToGroupResponse(Team team){
+        return SearchGroupResponseDto.builder()
+            .groupId(team.getGroupId())
+            .groupName(team.getGroupName())
+            .introduction(team.getIntroduction())
+            .userCount(team.getUserTeams().size())
+            .retrospectCount(retrospectRepository.countByGroupId(team.getGroupId()))
+            .build();
     }
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) resolve #136

## 📝 작업 내용

> 전체 통합검색을 수행합니다. 모임의 경우 모임명과 한줄소개에 해당키워드가, 회고의 경우 제목이나 내용에 해당 키워드가 있을 것들을 반환합니다. 피그마 보면 옆에 모임과 회고 따로 조회하는게 있는데, 이건 페이지네이션적용이 필요해서 따로 작업할 예정입니다.
## 💬 리뷰 요구사항 (선택 사항)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
api를 모임따로 회고따로 2번 요청해서 커넥션을 2개 사용하기 보단, 전체 통합검색에서는 페이징도 필요 없고, 한번의 요청으로 모임과 회고 다 반환하였습니다. 나중에 옆에 회고따로 모임따로 조회할때는 페이징이 필요하기 때문에 api를 분리해서 따로 반환하려고 하는데 괜찮을까요?? 