### PR TITLE
fix : GET, OPTION 요청도 filter를 거치도록 수정

### DIFF
--- a/src/main/java/com/dnd/reevserver/global/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/reevserver/global/jwt/filter/JwtAuthenticationFilter.java
@@ -39,9 +39,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
      */
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        return request.getMethod().equalsIgnoreCase("GET") ||
-                request.getMethod().equalsIgnoreCase("OPTIONS") ||
-                Arrays.stream(SecurityEndpointPaths.WHITE_LIST)
+        return Arrays.stream(SecurityEndpointPaths.WHITE_LIST)
                         .anyMatch(path -> PatternMatchUtils.simpleMatch(path, request.getRequestURI()));
     }
     /**


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #163

## 📝 작업 내용

filter에서 본래 토큰을 검사하는데, 모든 GET 요청이 이 filter를 거쳐야 하는데 착오로 인해 GET 요청을 거치지 않게 하였네요. 수정하였습니다.