### PR TITLE
feat : 초대 링크 생성 및 접속 구현

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
@@ -98,11 +98,13 @@ public class TeamController implements TeamControllerDocs{
     }
 
     @GetMapping("/invite/{uuid}")
-    public ResponseEntity<?> handleInvite(@PathVariable String uuid) {
-        boolean exists = groupService.handleInvite(uuid);
-        if (!exists) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("초대 링크가 유효하지 않거나 만료되었습니다.");
+    public ResponseEntity<TeamInviteResponseDto> handleInvite(@PathVariable String uuid) {
+        TeamInviteResponseDto response = groupService.handleInvite(uuid);
+
+        if (!response.valid()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
         }
-        return ResponseEntity.ok("초대 링크가 유효합니다.");
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamController.java
@@ -4,6 +4,7 @@ import com.dnd.reevserver.domain.team.dto.request.*;
 import com.dnd.reevserver.domain.team.dto.response.*;
 import com.dnd.reevserver.domain.team.service.TeamService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -91,5 +92,17 @@ public class TeamController implements TeamControllerDocs{
         return ResponseEntity.ok().body(response);
     }
 
+    @PostMapping("/invite")
+    public ResponseEntity<CreateTeamInviteLinkResponseDto> createInviteLink(@AuthenticationPrincipal String userId, @RequestBody CreateTeamInviteLinkRequestDto requestDto){
+        return ResponseEntity.ok().body(groupService.createTeamInviteLink(userId, requestDto));
+    }
 
+    @GetMapping("/invite/{uuid}")
+    public ResponseEntity<?> handleInvite(@PathVariable String uuid) {
+        boolean exists = groupService.handleInvite(uuid);
+        if (!exists) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("초대 링크가 유효하지 않거나 만료되었습니다.");
+        }
+        return ResponseEntity.ok("초대 링크가 유효합니다.");
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
@@ -1,29 +1,13 @@
 package com.dnd.reevserver.domain.team.controller;
 
-import com.dnd.reevserver.domain.team.dto.request.AddFavoriteGroupRequestDto;
-import com.dnd.reevserver.domain.team.dto.request.AddTeamRequestDto;
-import com.dnd.reevserver.domain.team.dto.request.GetRecommendGroupRequestDto;
-import com.dnd.reevserver.domain.team.dto.request.JoinGroupRequestDto;
-import com.dnd.reevserver.domain.team.dto.request.LeaveGroupRequestDto;
-import com.dnd.reevserver.domain.team.dto.request.UpdateGroupRequestDto;
-import com.dnd.reevserver.domain.team.dto.response.AddFavoriteGroupResponseDto;
-import com.dnd.reevserver.domain.team.dto.response.AddTeamResponseDto;
-import com.dnd.reevserver.domain.team.dto.response.GetPopularGroupResponseDto;
-import com.dnd.reevserver.domain.team.dto.response.GroupDetailResponseDto;
-import com.dnd.reevserver.domain.team.dto.response.JoinGroupResponseDto;
-import com.dnd.reevserver.domain.team.dto.response.LeaveGroupResponseDto;
-import com.dnd.reevserver.domain.team.dto.response.TeamResponseDto;
+import com.dnd.reevserver.domain.team.dto.request.*;
+import com.dnd.reevserver.domain.team.dto.response.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "그룹 API", description = "모임과 관련한 API입니다.")
 public interface TeamControllerDocs {
@@ -64,4 +48,9 @@ public interface TeamControllerDocs {
     @Operation(summary = "모임 탐색 API", description = "모임을 검색합니다.")
     public ResponseEntity<List<TeamResponseDto>> searchGroups(@RequestParam(required = false) String title,  @RequestParam(required = false) List<String> categories);
 
+    @Operation(summary = "모임 초대 링크 생성 API", description = "모임을 초대하는 링크를 생성합니다. userId가 group 내에 속해있지 않으면 예외처리합니다. 생성된 링크는 2시간 뒤 삭제됩니다.")
+    public ResponseEntity<CreateTeamInviteLinkResponseDto> createInviteLink(@AuthenticationPrincipal String userId, @RequestBody CreateTeamInviteLinkRequestDto requestDto);
+
+    @Operation(summary = "모임 초대 링크 들어가기", description = "모임 초대 링크를 들어갑니다. 생성된 링크가 아니면 초대X 및 404 리턴, 맟으면 초대합니다.")
+    public ResponseEntity<?> handleInvite(@PathVariable String uuid);
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/controller/TeamControllerDocs.java
@@ -52,5 +52,5 @@ public interface TeamControllerDocs {
     public ResponseEntity<CreateTeamInviteLinkResponseDto> createInviteLink(@AuthenticationPrincipal String userId, @RequestBody CreateTeamInviteLinkRequestDto requestDto);
 
     @Operation(summary = "모임 초대 링크 들어가기", description = "모임 초대 링크를 들어갑니다. 생성된 링크가 아니면 초대X 및 404 리턴, 맟으면 초대합니다.")
-    public ResponseEntity<?> handleInvite(@PathVariable String uuid);
+    public ResponseEntity<TeamInviteResponseDto> handleInvite(@PathVariable String uuid);
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/dto/request/CreateTeamInviteLinkRequestDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/dto/request/CreateTeamInviteLinkRequestDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.team.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record CreateTeamInviteLinkRequestDto(Long groupId) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/team/dto/response/CreateTeamInviteLinkResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/dto/response/CreateTeamInviteLinkResponseDto.java
@@ -1,0 +1,4 @@
+package com.dnd.reevserver.domain.team.dto.response;
+
+public record CreateTeamInviteLinkResponseDto(String link) {
+}

--- a/src/main/java/com/dnd/reevserver/domain/team/dto/response/TeamInviteResponseDto.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/dto/response/TeamInviteResponseDto.java
@@ -1,0 +1,7 @@
+package com.dnd.reevserver.domain.team.dto.response;
+
+public record TeamInviteResponseDto(
+        boolean valid,
+        Long groupId,
+        String message
+) {}

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamLinkRepository.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamLinkRepository.java
@@ -1,0 +1,43 @@
+package com.dnd.reevserver.domain.team.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemResponse;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+
+import java.time.Duration;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class TeamLinkRepository {
+    private final DynamoDbClient dynamoDbClient;
+
+    @Value("${cloud.aws.dynamodb.name.team.link}")
+    private String TABLE_NAME;
+
+    private static final String PK = "uuid";
+
+    public void save(String uuid, Duration expiration) {
+        dynamoDbClient.putItem(PutItemRequest.builder()
+                .tableName(TABLE_NAME)
+                .item(Map.of(
+                        PK, AttributeValue.fromS(uuid),
+                        "ttl", AttributeValue.fromN(String.valueOf((System.currentTimeMillis() / 1000) + expiration.getSeconds()))
+                ))
+                .build());
+    }
+
+    public boolean existsUuid(String uuid) {
+        GetItemResponse response = dynamoDbClient.getItem(GetItemRequest.builder()
+                .tableName(TABLE_NAME)
+                .key(Map.of(PK, AttributeValue.fromS(uuid)))
+                .build());
+
+        return response.hasItem();
+    }
+}

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -265,13 +265,15 @@ public class TeamService {
         findByUserIdAndGroupId(userId, dto.groupId());
         String uuid = UUID.randomUUID().toString();
         String link = BASE_URL + "api/v1/group/invite/" + uuid;
-        teamLinkRepository.save(uuid, Duration.ofHours(2));
+        teamLinkRepository.save(uuid, dto.groupId(), Duration.ofHours(2));
         return new CreateTeamInviteLinkResponseDto(link);
     }
 
     // 초대 링크 검사
-    public boolean handleInvite(String uuid){
-        return teamLinkRepository.existsUuid(uuid);
+    public TeamInviteResponseDto handleInvite(String uuid) {
+        return teamLinkRepository.findGroupIdByUuid(uuid)
+                .map(groupId -> new TeamInviteResponseDto(true, groupId, "초대 링크가 유효합니다."))
+                .orElseGet(() -> new TeamInviteResponseDto(false, null, "초대 링크가 유효하지 않거나 만료되었습니다."));
     }
 
     //그룹 검색

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -20,6 +20,7 @@ import com.dnd.reevserver.domain.team.dto.response.*;
 import com.dnd.reevserver.domain.team.entity.Team;
 import com.dnd.reevserver.domain.team.exception.NotOwnerUserException;
 import com.dnd.reevserver.domain.team.exception.TeamNotFoundException;
+import com.dnd.reevserver.domain.team.repository.TeamLinkRepository;
 import com.dnd.reevserver.domain.team.repository.TeamRepository;
 import com.dnd.reevserver.domain.member.entity.Member;
 import com.dnd.reevserver.domain.member.service.MemberService;
@@ -29,9 +30,11 @@ import com.dnd.reevserver.domain.userTeam.exception.UserGroupNotFoundException;
 import com.dnd.reevserver.domain.userTeam.repository.UserTeamRepository;
 import com.dnd.reevserver.global.util.TimeStringUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -40,6 +43,9 @@ import java.util.UUID;
 @Service
 @RequiredArgsConstructor
 public class TeamService {
+
+    @Value("${invite.base-url}")
+    private String BASE_URL;
 
     private final TeamRepository teamRepository;
     private final UserTeamRepository userTeamRepository;
@@ -53,6 +59,7 @@ public class TeamService {
     private final TeamCategoryService teamCategoryService;
     private final LikeRepository likeRepository;
     private final AlertService alertService;
+    private final TeamLinkRepository teamLinkRepository;
 
     //모든 그룹조회
     @Transactional(readOnly = true)
@@ -252,6 +259,21 @@ public class TeamService {
         return groupId;
     }
 
+    // 그룹 초대
+    @Transactional(readOnly = true)
+    public CreateTeamInviteLinkResponseDto createTeamInviteLink(String userId, CreateTeamInviteLinkRequestDto dto) {
+        findByUserIdAndGroupId(userId, dto.groupId());
+        String uuid = UUID.randomUUID().toString();
+        String link = BASE_URL + "api/v1/group/invite/" + uuid;
+        teamLinkRepository.save(uuid, Duration.ofHours(2));
+        return new CreateTeamInviteLinkResponseDto(link);
+    }
+
+    // 초대 링크 검사
+    public boolean handleInvite(String uuid){
+        return teamLinkRepository.existsUuid(uuid);
+    }
+
     //그룹 검색
     @Transactional(readOnly = true)
     public List<TeamResponseDto> searchGroups(String title, List<String> categories){
@@ -262,7 +284,6 @@ public class TeamService {
             .toList();
 
     }
-
 
     //통합검색에서 검색
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

* resolve #170 

## 📝 작업 내용

* 초대 링크를 생성하는 API를 만들었습니다.
* https://api.xxxx.kr/api/v1/group/invite/UUID 형식으로 링크가 생성되며, 이 때 UUID와 groupId는 DynamoDB에 저장됩니다.
  * 생성할 때 생성하는 사람이 그룹 내 사람이 아니면 404를 리턴합니다.
  * 해당 링크는 2시간 뒤 삭제됩니다. (TTL 적용)
* 해당 링크 GET 요청 시 DynamoDB에서 해당 UUID를 찾고, 있으면 초대 가능 주소가 된다는 boolean과 groupId, 메시지를 반환, 없을 경우 404를 반환합니다.
  * 리다이렉션 등 여러 방법이 있겠지만, 우선 이렇게만 하는 걸로 하겠습니다.

## 💬 리뷰 요구사항 (선택 사항)

* **application.properties 변경되었습니다.**