### PR TITLE
Feat/#165 통합검색 상세

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepositoryCustom.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/repository/RetrospectRepositoryCustom.java
@@ -2,7 +2,10 @@ package com.dnd.reevserver.domain.retrospect.repository;
 
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface RetrospectRepositoryCustom {
     List<Retrospect> searchForKeyword(String keyword);
+    Slice<Retrospect> searchForKeywordParti(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
+++ b/src/main/java/com/dnd/reevserver/domain/retrospect/service/RetrospectService.java
@@ -24,6 +24,8 @@ import com.dnd.reevserver.domain.team.entity.Team;
 import com.dnd.reevserver.domain.team.service.TeamService;
 import com.dnd.reevserver.global.util.TimeStringUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import jakarta.persistence.Tuple;
@@ -215,6 +217,13 @@ public class RetrospectService {
         return retrospects.stream()
             .map(this::convertToRetrospectResponse)
             .toList();
+    }
+
+    //통합검색후 상세
+    @Transactional(readOnly = true)
+    public Slice<SearchRetrospectResponseDto> searchForKeywordParti(String keyword, Pageable pageable){
+         return retrospectRepository.searchForKeywordParti(keyword, pageable)
+            .map(this::convertToRetrospectResponse);
     }
 
 

--- a/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
@@ -34,9 +34,8 @@ public class SearchController {
         return searchService.searchAllRetrospect(keyword, pageable);
     }
 
-//    @GetMapping("/group")
-//    public ResponseEntity<SearchAllResponseDto> searchPartiGroup (@RequestParam(required = false) String keyword){
-//        SearchAllResponseDto response = searchService.searchAll(keyword);
-//        return ResponseEntity.ok().body(response);
-//    }
+    @GetMapping("/group")
+    public Slice<SearchGroupResponseDto> searchPartiGroup (@RequestParam(required = false) String keyword, @PageableDefault(size = 3) Pageable pageable){
+        return searchService.searchAllGroup(keyword, pageable);
+    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/controller/SearchController.java
@@ -1,9 +1,14 @@
 package com.dnd.reevserver.domain.search.controller;
 
 import com.dnd.reevserver.domain.search.dto.response.SearchAllResponseDto;
+import com.dnd.reevserver.domain.search.dto.response.SearchGroupResponseDto;
+import com.dnd.reevserver.domain.search.dto.response.SearchRetrospectResponseDto;
 import com.dnd.reevserver.domain.search.service.SearchService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.parameters.P;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,4 +28,15 @@ public class SearchController {
         SearchAllResponseDto response = searchService.searchAll(keyword);
         return ResponseEntity.ok().body(response);
     }
+
+    @GetMapping("/retro")
+    public Slice<SearchRetrospectResponseDto> searchPartiRetro (@RequestParam(required = false) String keyword, @PageableDefault(size = 3) Pageable pageable){
+        return searchService.searchAllRetrospect(keyword, pageable);
+    }
+
+//    @GetMapping("/group")
+//    public ResponseEntity<SearchAllResponseDto> searchPartiGroup (@RequestParam(required = false) String keyword){
+//        SearchAllResponseDto response = searchService.searchAll(keyword);
+//        return ResponseEntity.ok().body(response);
+//    }
 }

--- a/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
@@ -37,5 +37,10 @@ public class SearchService {
         return retrospectService.searchForKeywordParti(keyword, pageable);
     }
 
+    @Transactional(readOnly = true)
+    public Slice<SearchGroupResponseDto> searchAllGroup(String keyword, Pageable pageable){
+        return teamService.searchForKeywordParti(keyword, pageable);
+    }
+
 
 }

--- a/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
+++ b/src/main/java/com/dnd/reevserver/domain/search/service/SearchService.java
@@ -12,6 +12,8 @@ import com.dnd.reevserver.domain.team.service.TeamService;
 import com.dnd.reevserver.global.util.TimeStringUtil;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,6 +30,11 @@ public class SearchService {
         List<SearchGroupResponseDto> groups = teamService.searchForKeyword(keyword);
         List<SearchRetrospectResponseDto> retrospects = retrospectService.searchForKeyword(keyword);
         return new SearchAllResponseDto(groups, retrospects);
+    }
+
+    @Transactional(readOnly = true)
+    public Slice<SearchRetrospectResponseDto> searchAllRetrospect(String keyword, Pageable pageable){
+        return retrospectService.searchForKeywordParti(keyword, pageable);
     }
 
 

--- a/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/repository/TeamRepositoryCustom.java
@@ -1,11 +1,15 @@
 package com.dnd.reevserver.domain.team.repository;
 
+import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.team.dto.request.GroupSearchCondition;
 import com.dnd.reevserver.domain.team.dto.response.TeamResponseDto;
 import com.dnd.reevserver.domain.team.entity.Team;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface TeamRepositoryCustom {
     List<Team> search(GroupSearchCondition condition);
     List<Team> searchForKeyword(String keyword);
+    Slice<Team> searchForKeywordParti(String keyword, Pageable pageable);
 }

--- a/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
+++ b/src/main/java/com/dnd/reevserver/domain/team/service/TeamService.java
@@ -15,6 +15,7 @@ import com.dnd.reevserver.domain.retrospect.dto.response.RetrospectResponseDto;
 import com.dnd.reevserver.domain.retrospect.entity.Retrospect;
 import com.dnd.reevserver.domain.retrospect.repository.RetrospectRepository;
 import com.dnd.reevserver.domain.search.dto.response.SearchGroupResponseDto;
+import com.dnd.reevserver.domain.search.dto.response.SearchRetrospectResponseDto;
 import com.dnd.reevserver.domain.team.dto.request.*;
 import com.dnd.reevserver.domain.team.dto.response.*;
 import com.dnd.reevserver.domain.team.entity.Team;
@@ -31,6 +32,8 @@ import com.dnd.reevserver.domain.userTeam.repository.UserTeamRepository;
 import com.dnd.reevserver.global.util.TimeStringUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -294,6 +297,13 @@ public class TeamService {
         return groups.stream()
             .map(this::convertToGroupResponse)
             .toList();
+    }
+
+    //통합검색후 상세
+    @Transactional(readOnly = true)
+    public Slice<SearchGroupResponseDto> searchForKeywordParti(String keyword, Pageable pageable){
+        return teamRepository.searchForKeywordParti(keyword, pageable)
+            .map(this::convertToGroupResponse);
     }
 
     public Team findById(Long groupId) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) resolve #165

## 📝 작업 내용

> 통합검색에서의 항목별 상세 창을 구현하였습니다.
무한 스크롤의 경우 커서 기반 페이지네이션으로 구현하면 성능상 이점이 있다고 하는데, 나중에 성능개선때 차이를 확인해 보기 위해 우선 offest기반으로 slice를 사용하여 전체 카운트 쿼리는 발생하지 않도록 하였습니다.
참고한 글: https://rachel0115.tistory.com/entry/QueryDsl-Page-Slice-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98-%EB%AC%B4%ED%95%9C-%EC%8A%A4%ED%81%AC%EB%A1%A4
성능 개선 작업하면서 바꿔보겠습니다!

## 💬 리뷰 요구사항 (선택 사항)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요