### PR TITLE
feat : memo 생성/수정 시 templateId = 0일 때의 로직 추가

### DIFF
--- a/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
+++ b/src/main/java/com/dnd/reevserver/domain/memo/service/MemoService.java
@@ -73,7 +73,7 @@ public class MemoService {
                     .title(dto.title())
                     .content(dto.content())
                     .team(dto.groupId() == null ? null : teamService.findById(dto.groupId())) // null 가능
-                    .template(templateService.findById(dto.templateId()))
+                    .template(dto.templateId() == 0 ? null : templateService.findById(dto.templateId()))
                     .build();
         // 메모-태그 생성
         memoRepository.save(memo);
@@ -97,7 +97,9 @@ public class MemoService {
         memo.updateTitle(dto.title());
         memo.updateContent(dto.content());
         memo.updateTeam(dto.groupId() == null ? null : teamService.findById(dto.groupId()));
-        memo.updateTemplate(templateService.findById(dto.templateId()));
+
+        if(dto.templateId() != 0)
+            memo.updateTemplate(templateService.findById(dto.templateId()));
 
         memoRepository.deleteAllByMemo(memo);
         memo.clearMemoCategory();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

resolve #182 

## 📝 작업 내용
* 임시 글 생성/수정 시 템플릿을 사용하지 않는 경우인 template = 0인 경우에 대한 처리 추가

## 💬 리뷰 요구사항 (선택 사항)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요